### PR TITLE
feat: HTTP Range resume and multipart downloads (#13)

### DIFF
--- a/icedtea-web-integration/src/test/java/net/sourceforge/jnlp/integration/HttpRangeResumeIT.java
+++ b/icedtea-web-integration/src/test/java/net/sourceforge/jnlp/integration/HttpRangeResumeIT.java
@@ -423,9 +423,61 @@ public class HttpRangeResumeIT {
         assertArrayEquals(fullJar, Files.readAllBytes(cachedJar));
     }
 
+    /**
+     * A range-unaware server (IGNORE) answers a jar's Range probe with a full 200. The session
+     * must remember that this origin ignores Range so jars that start later in the same launch
+     * use a plain GET — the slot/size-first algorithm stays active (its initial lanes probe, the
+     * note registers on the first 200, and lane-refill jars stop sending Range). Many jars ⇒
+     * only the first few probe, not one probe per jar.
+     */
+    @Test
+    void sessionRemembersIgnoredRangeAcrossJars() throws Exception {
+        writeUserDeploymentProperty("deployment.http.range.maxSlotBytes", "64");
+        mode = RangeMode.IGNORE;
+
+        int jarCount = 5;
+        for (int i = 2; i <= jarCount; i++) {
+            Files.write(webRoot.resolve("headless-app" + i + ".jar"), fullJar);
+        }
+        String[] jars = new String[jarCount];
+        for (int i = 0; i < jarCount; i++) {
+            jars[i] = i == 0 ? JAR_NAME : "headless-app" + (i + 1) + ".jar";
+        }
+
+        Path marker = markerDir.resolve("multi.marker");
+        writeJnlp(marker, jars);
+        LaunchResult result = launch(marker);
+
+        assertTrue(result.success, "multi-jar launch must succeed via plain GETs:\n" + result.output);
+        assertEquals(jarCount, jarGets.get(), "every jar must be downloaded");
+        assertTrue(rangeRequests.get() >= 1,
+                "at least the initial lane(s) must probe Range");
+        assertTrue(rangeRequests.get() < jarGets.get(),
+                "not every jar may probe Range; the session must remember the host ignores it "
+                        + "(saw " + rangeRequests.get() + " Range requests for " + jarGets.get()
+                        + " jar GETs)");
+        assertEquals(0, count206.get(), "range-unaware server never serves 206");
+
+        for (int i = 0; i < jarCount; i++) {
+            Path cached = findCachedJar(cacheHome, jars[i]);
+            assertNotNull(cached, jars[i] + " must be cached");
+            assertEquals(fullJar.length, Files.size(cached), jars[i] + " must be whole");
+            assertArrayEquals(fullJar, Files.readAllBytes(cached));
+        }
+    }
+
     // ----- helpers -----
 
     private void writeJnlp(Path marker) throws Exception {
+        writeJnlp(marker, JAR_NAME);
+    }
+
+    private void writeJnlp(Path marker, String... jars) throws Exception {
+        StringBuilder jarsXml = new StringBuilder();
+        for (int i = 0; i < jars.length; i++) {
+            jarsXml.append("    <jar href=\"").append(jars[i]).append("\"")
+                    .append(i == 0 ? " main=\"true\"" : "").append("/>\n");
+        }
         String jnlp = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
                 + "<jnlp spec=\"1.0+\" codebase=\"http://127.0.0.1:" + httpPort + "/\" href=\"range-resume.jnlp\">\n"
                 + "  <information><title>ITW range resume</title><vendor>ITW</vendor></information>\n"
@@ -434,7 +486,7 @@ public class HttpRangeResumeIT {
                 + "    <property name=\"itw.test.success.marker\" value=\""
                 + marker.toAbsolutePath().toString().replace("\\", "/") + "\"/>\n"
                 + "    <j2se version=\"1.8+\"/>\n"
-                + "    <jar href=\"" + JAR_NAME + "\" main=\"true\"/>\n"
+                + jarsXml
                 + "  </resources>\n"
                 + "  <application-desc main-class=\"net.sourceforge.jnlp.integration.HeadlessJnlpMain\"/>\n"
                 + "</jnlp>\n";
@@ -622,7 +674,10 @@ public class HttpRangeResumeIT {
                 return;
             }
 
-            jarGets.incrementAndGet();
+            boolean isGet = "GET".equalsIgnoreCase(exchange.getRequestMethod().toString());
+            if (isGet) {
+                jarGets.incrementAndGet();
+            }
             String rangeHeader = exchange.getRequestHeaders().getFirst(Headers.RANGE);
             if (rangeHeader != null) {
                 rangeRequests.incrementAndGet();

--- a/icedtea-web-integration/src/test/java/net/sourceforge/jnlp/integration/HttpRangeResumeIT.java
+++ b/icedtea-web-integration/src/test/java/net/sourceforge/jnlp/integration/HttpRangeResumeIT.java
@@ -210,6 +210,84 @@ public class HttpRangeResumeIT {
         assertArrayEquals(fullJar, Files.readAllBytes(replaced));
     }
 
+    /**
+     * A 416 (Range Not Satisfiable) must trigger a single full-GET fallback on the same URL,
+     * not a download failure. Asserts both responses (416 then 200) occur and the app launches.
+     */
+    @Test
+    void unsatisfiableRangeFallsBackToFullGet() throws Exception {
+        mode = RangeMode.REJECT_416;
+
+        Path marker1 = markerDir.resolve("success1.marker");
+        writeJnlp(marker1);
+        LaunchResult first = launch(marker1);
+        assertTrue(first.success, "initial launch must populate cache:\n" + first.output);
+
+        Path cachedJar = findCachedJar(cacheHome, JAR_NAME);
+        assertNotNull(cachedJar, "expected cached " + JAR_NAME);
+        int cut = Math.max(8, fullJar.length / 2);
+        truncate(cachedJar, cut);
+
+        resetCaptures();
+        Path marker2 = markerDir.resolve("success2.marker");
+        writeJnlp(marker2);
+        LaunchResult second = launch(marker2);
+
+        assertTrue(second.success, "relaunch must succeed after 416 fallback:\n" + second.output);
+        assertEquals("bytes=" + cut + "-", lastRangeHeader.get(),
+                "client must first attempt the Range resume");
+        assertTrue(count416.get() >= 1, "server must reject the range with 416");
+        assertTrue(count200.get() >= 1, "client must fall back to a full 200 GET after 416");
+        assertEquals(0, count206.get(), "no 206 should be served when the range is rejected");
+
+        Path replaced = findCachedJar(cacheHome, JAR_NAME);
+        assertNotNull(replaced);
+        assertEquals(fullJar.length, Files.size(replaced), "fallback full GET must restore full length");
+        assertArrayEquals(fullJar, Files.readAllBytes(replaced));
+    }
+
+    /**
+     * When the resource changed since the partial was cached, the client's If-Range must make
+     * the server answer with a full 200 (not a 206 suffix), so the stale prefix is replaced
+     * rather than appended to. Exercises the RFC 7233 If-Range safety path end-to-end.
+     */
+    @Test
+    void ifRangeStaleForcesFullReplace() throws Exception {
+        long t1 = 1_700_000_000_000L;
+        resourceLastModified = t1;
+        mode = RangeMode.IF_RANGE;
+
+        Path marker1 = markerDir.resolve("success1.marker");
+        writeJnlp(marker1);
+        LaunchResult first = launch(marker1);
+        assertTrue(first.success, "initial launch must populate cache:\n" + first.output);
+
+        Path cachedJar = findCachedJar(cacheHome, JAR_NAME);
+        assertNotNull(cachedJar, "expected cached " + JAR_NAME);
+        int cut = Math.max(8, fullJar.length / 2);
+        truncate(cachedJar, cut);
+
+        // Simulate the resource changing on the server between the two launches.
+        resourceLastModified = t1 + 70_000L;
+
+        resetCaptures();
+        Path marker2 = markerDir.resolve("success2.marker");
+        writeJnlp(marker2);
+        LaunchResult second = launch(marker2);
+
+        assertTrue(second.success, "relaunch must succeed via full GET:\n" + second.output);
+        assertNotNull(lastIfRangeHeader.get(),
+                "client must send If-Range when it cached a Last-Modified");
+        assertEquals(0, count206.get(), "stale If-Range must NOT yield a 206 suffix");
+        assertTrue(count200.get() >= 1, "stale If-Range must yield a full 200 replacement");
+
+        Path replaced = findCachedJar(cacheHome, JAR_NAME);
+        assertNotNull(replaced);
+        assertEquals(fullJar.length, Files.size(replaced),
+                "stale prefix must be replaced, not appended");
+        assertArrayEquals(fullJar, Files.readAllBytes(replaced));
+    }
+
     // ----- helpers -----
 
     private void writeJnlp(Path marker) throws Exception {

--- a/icedtea-web-integration/src/test/java/net/sourceforge/jnlp/integration/HttpRangeResumeIT.java
+++ b/icedtea-web-integration/src/test/java/net/sourceforge/jnlp/integration/HttpRangeResumeIT.java
@@ -1,0 +1,531 @@
+package net.sourceforge.jnlp.integration;
+
+import io.undertow.Undertow;
+import io.undertow.server.HttpHandler;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.util.Headers;
+import io.undertow.util.StatusCodes;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+/**
+ * End-to-end integration tests for HTTP Range (RFC 7233) JAR-cache resume
+ * (gitea2 mhickson/icedtea-web #13). Each test launches a real {@code javaws}
+ * against an Undertow server that can honour / ignore / reject Range requests,
+ * truncates the cached jar to simulate an interrupted download, then relaunches
+ * and asserts ITW resumes (206 append) or falls back (200 / 416 / mismatch) and
+ * the application still launches with an intact, verifiable jar.
+ */
+public class HttpRangeResumeIT {
+
+    private static final String JAVAWS_BIN = System.getProperty("itw.javaws.bin");
+    private static final String JDK_HOME = firstNonBlank(
+            System.getProperty("itw.jdk11.home"),
+            System.getProperty("itw.jdk17.home"),
+            System.getProperty("itw.jdk8.home"));
+    private static final int TIMEOUT_SECONDS = Integer.getInteger("itw.launch.timeout.seconds", 180);
+    private static final String JAR_NAME = "headless-app.jar";
+
+    private Undertow server;
+    private int httpPort;
+    private Path webRoot;
+    private Path markerDir;
+    private Path cacheHome;
+    private Path configHome;
+    private byte[] fullJar;
+
+    /** Range-serving behaviour applied to every jar GET. Mutable so a test can change it. */
+    private volatile RangeMode mode = RangeMode.HONOR;
+    /** Last-Modified (epoch millis) advertised for the jar; bumped to simulate a changed resource. */
+    private volatile long resourceLastModified = 0L;
+
+    private final AtomicInteger jarGets = new AtomicInteger();
+    private final AtomicReference<String> lastRangeHeader = new AtomicReference<>();
+    private final AtomicReference<String> lastIfRangeHeader = new AtomicReference<>();
+    private final AtomicInteger count206 = new AtomicInteger();
+    private final AtomicInteger count200 = new AtomicInteger();
+    private final AtomicInteger count416 = new AtomicInteger();
+
+    enum RangeMode {
+        /** Honour a byte Range with 206 + suffix. */
+        HONOR,
+        /** Ignore Range and always serve the full 200 body (old / range-unaware server). */
+        IGNORE,
+        /** Reject a Range with 416. */
+        REJECT_416,
+        /** Serve 206 with a Content-Range start of 0 (mismatches the requested suffix). */
+        MISMATCH,
+        /** Honour Range only when If-Range matches the current Last-Modified, else full 200. */
+        IF_RANGE
+    }
+
+    @BeforeEach
+    void setUp() throws Exception {
+        assumeTrue(JAVAWS_BIN != null && new File(JAVAWS_BIN).isFile(), "itw.javaws.bin missing");
+        assumeTrue(JDK_HOME != null && javaExecutableForHome(JDK_HOME).isFile(), "JDK home missing");
+
+        webRoot = Files.createTempDirectory("itw-range-web");
+        markerDir = Files.createTempDirectory("itw-range-marker");
+        cacheHome = Files.createTempDirectory("itw-range-cache");
+        configHome = Files.createTempDirectory("itw-range-config");
+
+        Path source = Paths.get("target", "icedtea-web-integration-2.0.1-SNAPSHOT-headless-app.jar");
+        assumeTrue(Files.exists(source), "headless-app jar missing: " + source.toAbsolutePath());
+        fullJar = Files.readAllBytes(source);
+        Files.copy(source, webRoot.resolve(JAR_NAME));
+
+        mode = RangeMode.HONOR;
+        resourceLastModified = 0L;
+        resetCaptures();
+
+        server = Undertow.builder()
+                .addHttpListener(0, "127.0.0.1")
+                .setHandler(new RangeJarHandler())
+                .build();
+        server.start();
+        httpPort = ((InetSocketAddress) server.getListenerInfo().get(0).getAddress()).getPort();
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (server != null) {
+            server.stop();
+        }
+        deleteRecursive(webRoot);
+        deleteRecursive(markerDir);
+        deleteRecursive(cacheHome);
+        deleteRecursive(configHome);
+    }
+
+    private void resetCaptures() {
+        jarGets.set(0);
+        lastRangeHeader.set(null);
+        lastIfRangeHeader.set(null);
+        count206.set(0);
+        count200.set(0);
+        count416.set(0);
+    }
+
+    /**
+     * Launch once (full download), truncate the cached jar to a prefix so the next launch
+     * must resume, relaunch, and assert the server saw a 206-producing Range request and the
+     * reassembled jar is whole and the app launched.
+     */
+    @Test
+    void resumeTruncatedJarAppendsSuffixAndLaunches() throws Exception {
+        mode = RangeMode.HONOR;
+
+        Path marker1 = markerDir.resolve("success1.marker");
+        writeJnlp(marker1);
+        LaunchResult first = launch(marker1);
+        assertTrue(first.success, "initial launch must populate cache:\n" + first.output);
+        assertFalse(first.output.contains("ZipException"),
+                "initial launch must not hit a ZipException:\n" + first.output);
+
+        Path cachedJar = findCachedJar(cacheHome, JAR_NAME);
+        assertNotNull(cachedJar, "expected cached " + JAR_NAME + " under " + cacheHome);
+        assertEquals(fullJar.length, Files.size(cachedJar), "first launch caches the whole jar");
+
+        int cut = Math.max(8, fullJar.length / 2);
+        truncate(cachedJar, cut);
+        assertFalse(isZipMagic(cachedJar) && Files.size(cachedJar) == fullJar.length,
+                "precondition: cache jar is now a truncated prefix");
+
+        resetCaptures();
+        Path marker2 = markerDir.resolve("success2.marker");
+        writeJnlp(marker2);
+        LaunchResult second = launch(marker2);
+
+        assertTrue(second.success, "relaunch after truncation must resume and succeed:\n" + second.output);
+        assertEquals("bytes=" + cut + "-", lastRangeHeader.get(),
+                "client must request the missing suffix by Range header");
+        assertTrue(count206.get() > 0, "server must have served a 206 Partial Content");
+        assertEquals(0, count416.get(), "no 416 expected when the range is satisfiable");
+
+        Path reassembled = findCachedJar(cacheHome, JAR_NAME);
+        assertNotNull(reassembled, "reassembled jar must be cached");
+        assertEquals(fullJar.length, Files.size(reassembled), "appended suffix must restore full length");
+        assertTrue(isZipMagic(reassembled), "reassembled jar must be a valid ZIP");
+        assertArrayPrefix(fullJar, reassembled, cut);
+    }
+
+    /**
+     * A range-unaware server (IGNORE) returns the full 200 body even when the client sends
+     * Range. ITW must replace (truncate), not append, and the app must launch.
+     */
+    @Test
+    void rangeUnawareServerReplacesAndLaunches() throws Exception {
+        mode = RangeMode.IGNORE;
+
+        Path marker1 = markerDir.resolve("success1.marker");
+        writeJnlp(marker1);
+        LaunchResult first = launch(marker1);
+        assertTrue(first.success, "initial launch must populate cache:\n" + first.output);
+
+        Path cachedJar = findCachedJar(cacheHome, JAR_NAME);
+        assertNotNull(cachedJar, "expected cached " + JAR_NAME);
+        int cut = Math.max(8, fullJar.length / 2);
+        truncate(cachedJar, cut);
+
+        resetCaptures();
+        Path marker2 = markerDir.resolve("success2.marker");
+        writeJnlp(marker2);
+        LaunchResult second = launch(marker2);
+
+        assertTrue(second.success, "relaunch must succeed via full GET:\n" + second.output);
+        assertNotNull(lastRangeHeader.get(), "client still sends Range because a partial exists");
+        assertTrue(count200.get() > 0, "range-unaware server serves a full 200");
+        assertEquals(0, count206.get(), "no 206 from a range-unaware server");
+
+        Path replaced = findCachedJar(cacheHome, JAR_NAME);
+        assertNotNull(replaced);
+        assertEquals(fullJar.length, Files.size(replaced),
+                "server ignored Range: client must replace, not append (no length doubling)");
+        assertArrayEquals(fullJar, Files.readAllBytes(replaced));
+    }
+
+    // ----- helpers -----
+
+    private void writeJnlp(Path marker) throws Exception {
+        String jnlp = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                + "<jnlp spec=\"1.0+\" codebase=\"http://127.0.0.1:" + httpPort + "/\" href=\"range-resume.jnlp\">\n"
+                + "  <information><title>ITW range resume</title><vendor>ITW</vendor></information>\n"
+                + "  <security><all-permissions/></security>\n"
+                + "  <resources>\n"
+                + "    <property name=\"itw.test.success.marker\" value=\""
+                + marker.toAbsolutePath().toString().replace("\\", "/") + "\"/>\n"
+                + "    <j2se version=\"1.8+\"/>\n"
+                + "    <jar href=\"" + JAR_NAME + "\" main=\"true\"/>\n"
+                + "  </resources>\n"
+                + "  <application-desc main-class=\"net.sourceforge.jnlp.integration.HeadlessJnlpMain\"/>\n"
+                + "</jnlp>\n";
+        Files.write(webRoot.resolve("range-resume.jnlp"), jnlp.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private LaunchResult launch(Path marker) throws Exception {
+        String jnlpUrl = "http://127.0.0.1:" + httpPort + "/range-resume.jnlp";
+        List<String> command = new ArrayList<>();
+        command.add(JAVAWS_BIN);
+        command.add("-headless");
+        command.add("-verbose");
+        command.add("-Xtrustall");
+        command.add("--auto-accept-https-certificate=true");
+        command.add("-Xnofork");
+        command.add(jnlpUrl);
+
+        ProcessBuilder pb = new ProcessBuilder(command);
+        pb.environment().put("JAVA_HOME", JDK_HOME);
+        pb.environment().put("ICEDTEA_WEB_SPLASH", "none");
+        pb.environment().put("XDG_CACHE_HOME", cacheHome.toAbsolutePath().toString());
+        pb.environment().put("XDG_CONFIG_HOME", configHome.toAbsolutePath().toString());
+        pb.redirectErrorStream(true);
+        Path outputFile = Files.createTempFile("itw-range", ".log");
+        pb.redirectOutput(outputFile.toFile());
+
+        Process process = pb.start();
+        boolean ok = waitForLaunchSuccess(process, outputFile, marker);
+        String output = new String(Files.readAllBytes(outputFile), StandardCharsets.UTF_8);
+        if (process.isAlive()) {
+            process.destroy();
+            process.waitFor(5, TimeUnit.SECONDS);
+            if (process.isAlive()) {
+                process.destroyForcibly();
+            }
+        }
+        return new LaunchResult(ok, output);
+    }
+
+    private static void truncate(Path file, int cut) throws Exception {
+        byte[] full = Files.readAllBytes(file);
+        Files.write(file, Arrays.copyOf(full, cut));
+    }
+
+    private static Path findCachedJar(Path cacheHome, String jarName) throws Exception {
+        if (!Files.exists(cacheHome)) {
+            return null;
+        }
+        try (Stream<Path> walk = Files.walk(cacheHome)) {
+            List<Path> matches = walk
+                    .filter(Files::isRegularFile)
+                    .filter(p -> p.getFileName().toString().equals(jarName))
+                    .collect(Collectors.toList());
+            return matches.isEmpty() ? null : matches.get(matches.size() - 1);
+        }
+    }
+
+    private static boolean isZipMagic(Path file) throws Exception {
+        if (file == null || !Files.isRegularFile(file) || Files.size(file) < 4) {
+            return false;
+        }
+        byte[] head = Files.readAllBytes(file);
+        return head[0] == 'P' && head[1] == 'K'
+                && ((head[2] == 3 && head[3] == 4) || (head[2] == 5 && head[3] == 6));
+    }
+
+    private static void assertArrayEquals(byte[] expected, byte[] actual) {
+        assertTrue(Arrays.equals(expected, actual),
+                "byte content mismatch (expected " + expected.length + " bytes, got " + actual.length + ")");
+    }
+
+    private static void assertArrayPrefix(byte[] expectedFull, Path actualFile, int prefixLen) throws Exception {
+        byte[] actual = Files.readAllBytes(actualFile);
+        boolean prefixOk = prefixLen <= actual.length;
+        for (int i = 0; prefixOk && i < prefixLen; i++) {
+            prefixOk = expectedFull[i] == actual[i];
+        }
+        assertTrue(prefixOk, "resumed prefix bytes must equal the original jar prefix");
+    }
+
+    private static boolean waitForLaunchSuccess(Process process, Path outputFile, Path marker) throws Exception {
+        long deadline = System.currentTimeMillis() + (TIMEOUT_SECONDS * 1000L);
+        while (System.currentTimeMillis() < deadline) {
+            if (Files.exists(marker)) {
+                return true;
+            }
+            if (Files.exists(outputFile)) {
+                String out = new String(Files.readAllBytes(outputFile), StandardCharsets.UTF_8);
+                if (out.contains("ITW_INTEGRATION_SUCCESS")) {
+                    return true;
+                }
+            }
+            if (!process.isAlive()) {
+                return Files.exists(marker)
+                        || (Files.exists(outputFile)
+                        && new String(Files.readAllBytes(outputFile), StandardCharsets.UTF_8)
+                        .contains("ITW_INTEGRATION_SUCCESS"));
+            }
+            Thread.sleep(500);
+        }
+        return false;
+    }
+
+    private static File javaExecutableForHome(String javaHome) {
+        String name = System.getProperty("os.name", "").toLowerCase().contains("windows")
+                ? "java.exe" : "java";
+        return new File(javaHome, "bin/" + name);
+    }
+
+    private static String firstNonBlank(String... values) {
+        if (values == null) {
+            return null;
+        }
+        for (String v : values) {
+            if (v != null && !v.trim().isEmpty()) {
+                return v;
+            }
+        }
+        return null;
+    }
+
+    private static void deleteRecursive(Path root) throws Exception {
+        if (root == null || !Files.exists(root)) {
+            return;
+        }
+        Files.walk(root)
+                .sorted((a, b) -> b.compareTo(a))
+                .forEach(path -> {
+                    try {
+                        Files.deleteIfExists(path);
+                    } catch (Exception ignored) {
+                    }
+                });
+    }
+
+    private static final class LaunchResult {
+        final boolean success;
+        final String output;
+
+        LaunchResult(boolean success, String output) {
+            this.success = success;
+            this.output = output;
+        }
+    }
+
+    /** Undertow handler: serves the JNLP and a Range-aware (RFC 7233) jar download. */
+    private final class RangeJarHandler implements HttpHandler {
+
+        @Override
+        public void handleRequest(HttpServerExchange exchange) throws Exception {
+            String path = exchange.getRelativePath();
+            if (path == null || path.isEmpty() || "/".equals(path)) {
+                exchange.setStatusCode(StatusCodes.NOT_FOUND);
+                return;
+            }
+            if (path.startsWith("/")) {
+                path = path.substring(1);
+            }
+            Path file = webRoot.resolve(path).normalize();
+            if (!file.startsWith(webRoot) || !Files.isRegularFile(file)) {
+                exchange.setStatusCode(StatusCodes.NOT_FOUND);
+                return;
+            }
+
+            byte[] body = Files.readAllBytes(file);
+            if (path.endsWith(".jnlp")) {
+                exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/x-java-jnlp-file");
+                exchange.getResponseSender().send(ByteBuffer.wrap(body));
+                return;
+            }
+            if (!path.endsWith(".jar")) {
+                exchange.getResponseSender().send(ByteBuffer.wrap(body));
+                return;
+            }
+
+            jarGets.incrementAndGet();
+            String rangeHeader = exchange.getRequestHeaders().getFirst(Headers.RANGE);
+            if (rangeHeader != null) {
+                lastRangeHeader.set(rangeHeader);
+            }
+            String ifRange = exchange.getRequestHeaders().getFirst(Headers.IF_RANGE);
+            if (ifRange != null) {
+                lastIfRangeHeader.set(ifRange);
+            }
+
+            // Honour HEAD-style probes with no body but correct full length metadata.
+            if (rangeHeader == null) {
+                count200.incrementAndGet();
+                serveFull(exchange, body);
+                return;
+            }
+
+            switch (mode) {
+                case IGNORE:
+                    count200.incrementAndGet();
+                    serveFull(exchange, body);
+                    return;
+                case REJECT_416:
+                    count416.incrementAndGet();
+                    rejectRange(exchange, body.length);
+                    return;
+                case IF_RANGE:
+                    if (ifRangeStale(ifRange)) {
+                        count200.incrementAndGet();
+                        serveFull(exchange, body);
+                        return;
+                    }
+                    // fall through to honour
+                case HONOR:
+                default:
+                    break;
+            }
+
+            long start = parseRangeStart(rangeHeader, body.length);
+            if (mode == RangeMode.MISMATCH) {
+                // Claim the suffix starts at 0 so it cannot line up with the requested offset.
+                count206.incrementAndGet();
+                servePartial(exchange, body, 0, body.length - 1);
+                return;
+            }
+            if (start < 0 || start >= body.length) {
+                count416.incrementAndGet();
+                rejectRange(exchange, body.length);
+                return;
+            }
+            count206.incrementAndGet();
+            servePartial(exchange, body, start, body.length - 1);
+        }
+
+        private void serveFull(HttpServerExchange exchange, byte[] body) {
+            exchange.setStatusCode(StatusCodes.OK);
+            exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/java-archive");
+            exchange.getResponseHeaders().put(Headers.ACCEPT_RANGES, "bytes");
+            addLastModified(exchange);
+            exchange.getResponseSender().send(ByteBuffer.wrap(body));
+        }
+
+        private void servePartial(HttpServerExchange exchange, byte[] body, long start, long end) {
+            exchange.setStatusCode(StatusCodes.PARTIAL_CONTENT);
+            exchange.getResponseHeaders().put(Headers.CONTENT_TYPE, "application/java-archive");
+            exchange.getResponseHeaders().put(Headers.ACCEPT_RANGES, "bytes");
+            exchange.getResponseHeaders().put(Headers.CONTENT_RANGE,
+                    "bytes " + start + "-" + end + "/" + body.length);
+            addLastModified(exchange);
+            int off = (int) start;
+            int len = (int) (end - start + 1);
+            exchange.getResponseSender().send(ByteBuffer.wrap(body, off, len));
+        }
+
+        private void rejectRange(HttpServerExchange exchange, int length) {
+            exchange.setStatusCode(416 /* Range Not Satisfiable */);
+            exchange.getResponseHeaders().put(Headers.ACCEPT_RANGES, "bytes");
+            exchange.getResponseHeaders().put(Headers.CONTENT_RANGE, "bytes */" + length);
+            exchange.getResponseHeaders().put(Headers.CONTENT_LENGTH, "0");
+            exchange.endExchange();
+        }
+
+        private void addLastModified(HttpServerExchange exchange) {
+            if (resourceLastModified > 0) {
+                exchange.getResponseHeaders().put(Headers.LAST_MODIFIED,
+                        Instant.ofEpochMilli(resourceLastModified).atZone(ZoneOffset.UTC)
+                                .format(DateTimeFormatter.RFC_1123_DATE_TIME));
+            }
+        }
+
+        /** RFC 7233 second-granularity If-Range comparison (mirrors the webstart servlet). */
+        private boolean ifRangeStale(String ifRange) {
+            if (resourceLastModified <= 0 || ifRange == null) {
+                return false;
+            }
+            try {
+                long ifRangeMillis = java.time.ZonedDateTime
+                        .parse(ifRange.trim(), DateTimeFormatter.RFC_1123_DATE_TIME)
+                        .toInstant().toEpochMilli();
+                return (ifRangeMillis / 1000L) < (resourceLastModified / 1000L);
+            } catch (Exception e) {
+                return false;
+            }
+        }
+
+        private long parseRangeStart(String rangeHeader, int length) {
+            String h = rangeHeader.trim();
+            int eq = h.indexOf('=');
+            if (eq == -1 || !h.substring(0, eq).trim().equalsIgnoreCase("bytes")) {
+                return -1;
+            }
+            String spec = h.substring(eq + 1).trim();
+            int comma = spec.indexOf(',');
+            if (comma != -1) {
+                spec = spec.substring(0, comma).trim();
+            }
+            int dash = spec.indexOf('-');
+            if (dash == -1) {
+                return -1;
+            }
+            String start = spec.substring(0, dash).trim();
+            try {
+                if (start.isEmpty()) {
+                    return -1; // suffix form not used by ITW resume requests
+                }
+                return Long.parseLong(start);
+            } catch (NumberFormatException e) {
+                return -1;
+            }
+        }
+    }
+}

--- a/icedtea-web-integration/src/test/java/net/sourceforge/jnlp/integration/HttpRangeResumeIT.java
+++ b/icedtea-web-integration/src/test/java/net/sourceforge/jnlp/integration/HttpRangeResumeIT.java
@@ -288,6 +288,81 @@ public class HttpRangeResumeIT {
         assertArrayEquals(fullJar, Files.readAllBytes(replaced));
     }
 
+    /**
+     * With {@code deployment.http.range.resume=false} the client must never send a Range
+     * header, so even a Range-capable server serves a plain 200 full download and the
+     * truncated cache is replaced. Guards the config escape hatch end-to-end.
+     */
+    @Test
+    void rangeDisabledDoesFullGetOnly() throws Exception {
+        writeUserDeploymentProperty("deployment.http.range.resume", "false");
+        mode = RangeMode.HONOR;
+
+        Path marker1 = markerDir.resolve("success1.marker");
+        writeJnlp(marker1);
+        LaunchResult first = launch(marker1);
+        assertTrue(first.success, "initial launch must populate cache:\n" + first.output);
+
+        Path cachedJar = findCachedJar(cacheHome, JAR_NAME);
+        assertNotNull(cachedJar, "expected cached " + JAR_NAME);
+        int cut = Math.max(8, fullJar.length / 2);
+        truncate(cachedJar, cut);
+
+        resetCaptures();
+        Path marker2 = markerDir.resolve("success2.marker");
+        writeJnlp(marker2);
+        LaunchResult second = launch(marker2);
+
+        assertTrue(second.success, "relaunch must succeed via full GET:\n" + second.output);
+        assertTrue(lastRangeHeader.get() == null,
+                "range resume disabled: client must not send a Range header");
+        assertEquals(0, count206.get(), "no 206 when range resume is disabled");
+        assertTrue(count200.get() >= 1, "disabled resume still full-downloads with 200");
+
+        Path replaced = findCachedJar(cacheHome, JAR_NAME);
+        assertNotNull(replaced);
+        assertEquals(fullJar.length, Files.size(replaced), "full GET must restore full length");
+        assertArrayEquals(fullJar, Files.readAllBytes(replaced));
+    }
+
+    /**
+     * A 206 whose Content-Range start does not line up with the on-disk prefix must be
+     * rejected by the client and retried as a full GET, so the suffix is never appended at
+     * the wrong offset. The server claims {@code bytes 0-} for a resume from {@code cut}.
+     */
+    @Test
+    void mismatchedContentRangeFallsBackToFullGet() throws Exception {
+        mode = RangeMode.MISMATCH;
+
+        Path marker1 = markerDir.resolve("success1.marker");
+        writeJnlp(marker1);
+        LaunchResult first = launch(marker1);
+        assertTrue(first.success, "initial launch must populate cache:\n" + first.output);
+
+        Path cachedJar = findCachedJar(cacheHome, JAR_NAME);
+        assertNotNull(cachedJar, "expected cached " + JAR_NAME);
+        int cut = Math.max(8, fullJar.length / 2);
+        truncate(cachedJar, cut);
+
+        resetCaptures();
+        Path marker2 = markerDir.resolve("success2.marker");
+        writeJnlp(marker2);
+        LaunchResult second = launch(marker2);
+
+        assertTrue(second.success, "relaunch must succeed after Content-Range mismatch:\n" + second.output);
+        assertEquals("bytes=" + cut + "-", lastRangeHeader.get(),
+                "client must first attempt the Range resume");
+        assertTrue(count206.get() >= 1, "server serves a 206 (with a mismatched Content-Range)");
+        assertTrue(count200.get() >= 1, "client must fall back to a full 200 GET after the mismatch");
+        assertEquals(0, count416.get(), "no 416 involved in a Content-Range mismatch");
+
+        Path replaced = findCachedJar(cacheHome, JAR_NAME);
+        assertNotNull(replaced);
+        assertEquals(fullJar.length, Files.size(replaced),
+                "mismatch fallback full GET must restore full length");
+        assertArrayEquals(fullJar, Files.readAllBytes(replaced));
+    }
+
     // ----- helpers -----
 
     private void writeJnlp(Path marker) throws Exception {
@@ -304,6 +379,18 @@ public class HttpRangeResumeIT {
                 + "  <application-desc main-class=\"net.sourceforge.jnlp.integration.HeadlessJnlpMain\"/>\n"
                 + "</jnlp>\n";
         Files.write(webRoot.resolve("range-resume.jnlp"), jnlp.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private void writeUserDeploymentProperty(String key, String value) throws Exception {
+        Path dir = configHome.resolve("icedtea-web");
+        Files.createDirectories(dir);
+        Path file = dir.resolve("deployment.properties");
+        String existing = Files.exists(file) ? new String(Files.readAllBytes(file), StandardCharsets.UTF_8) : "";
+        if (!existing.isEmpty() && !existing.endsWith("\n")) {
+            existing += "\n";
+        }
+        existing += key + "=" + value + "\n";
+        Files.write(file, existing.getBytes(StandardCharsets.UTF_8));
     }
 
     private LaunchResult launch(Path marker) throws Exception {

--- a/icedtea-web-integration/src/test/java/net/sourceforge/jnlp/integration/HttpRangeResumeIT.java
+++ b/icedtea-web-integration/src/test/java/net/sourceforge/jnlp/integration/HttpRangeResumeIT.java
@@ -67,6 +67,8 @@ public class HttpRangeResumeIT {
 
     private final AtomicInteger jarGets = new AtomicInteger();
     private final AtomicInteger rangeRequests = new AtomicInteger();
+    private final AtomicInteger flakyFailures = new AtomicInteger();
+    private final java.util.concurrent.ConcurrentHashMap<String, AtomicInteger> rangeAttempts = new java.util.concurrent.ConcurrentHashMap<>();
     private final AtomicReference<String> lastRangeHeader = new AtomicReference<>();
     private final AtomicReference<String> lastIfRangeHeader = new AtomicReference<>();
     private final AtomicInteger count206 = new AtomicInteger();
@@ -83,7 +85,9 @@ public class HttpRangeResumeIT {
         /** Serve 206 with a Content-Range start of 0 (mismatches the requested suffix). */
         MISMATCH,
         /** Honour Range only when If-Range matches the current Last-Modified, else full 200. */
-        IF_RANGE
+        IF_RANGE,
+        /** Fail the first attempt of each distinct Range with 503, then serve 206 (retry test). */
+        FLAKY_FIRST
     }
 
     @BeforeEach
@@ -127,6 +131,8 @@ public class HttpRangeResumeIT {
     private void resetCaptures() {
         jarGets.set(0);
         rangeRequests.set(0);
+        flakyFailures.set(0);
+        rangeAttempts.clear();
         lastRangeHeader.set(null);
         lastIfRangeHeader.set(null);
         count206.set(0);
@@ -394,6 +400,29 @@ public class HttpRangeResumeIT {
         assertArrayEquals(fullJar, Files.readAllBytes(cachedJar));
     }
 
+    /**
+     * The server fails the first attempt of every Range chunk with 503. The client must retry
+     * each chunk (and the probe via the resource-level retry) and still reassemble a whole,
+     * signature-verifiable jar and launch — proving per-chunk retry resilience end-to-end.
+     */
+    @Test
+    void multipartRetriesFlakyChunksAndLaunches() throws Exception {
+        writeUserDeploymentProperty("deployment.http.range.maxSlotBytes", "64");
+        mode = RangeMode.FLAKY_FIRST;
+
+        Path marker1 = markerDir.resolve("success1.marker");
+        writeJnlp(marker1);
+        LaunchResult first = launch(marker1);
+        assertTrue(first.success, "flaky multipart launch must recover via retries:\n" + first.output);
+        assertTrue(flakyFailures.get() > 0,
+                "expected at least one injected 503; the client must have retried past it: " + first.output);
+
+        Path cachedJar = findCachedJar(cacheHome, JAR_NAME);
+        assertNotNull(cachedJar, "reassembled jar must be cached");
+        assertEquals(fullJar.length, Files.size(cachedJar), "reassembled length must equal original");
+        assertArrayEquals(fullJar, Files.readAllBytes(cachedJar));
+    }
+
     // ----- helpers -----
 
     private void writeJnlp(Path marker) throws Exception {
@@ -602,6 +631,19 @@ public class HttpRangeResumeIT {
             String ifRange = exchange.getRequestHeaders().getFirst(Headers.IF_RANGE);
             if (ifRange != null) {
                 lastIfRangeHeader.set(ifRange);
+            }
+
+            // FLAKY_FIRST: fail the first attempt of each distinct Range with 503 to force the
+            // client's per-chunk (and resource-level) retry, then behave like HONOR.
+            if (mode == RangeMode.FLAKY_FIRST && rangeHeader != null) {
+                int attempt = rangeAttempts
+                        .computeIfAbsent(rangeHeader, k -> new AtomicInteger()).getAndIncrement();
+                if (attempt == 0) {
+                    flakyFailures.incrementAndGet();
+                    exchange.setStatusCode(StatusCodes.SERVICE_UNAVAILABLE);
+                    exchange.endExchange();
+                    return;
+                }
             }
 
             // Honour HEAD-style probes with no body but correct full length metadata.

--- a/icedtea-web-integration/src/test/java/net/sourceforge/jnlp/integration/HttpRangeResumeIT.java
+++ b/icedtea-web-integration/src/test/java/net/sourceforge/jnlp/integration/HttpRangeResumeIT.java
@@ -66,6 +66,7 @@ public class HttpRangeResumeIT {
     private volatile long resourceLastModified = 0L;
 
     private final AtomicInteger jarGets = new AtomicInteger();
+    private final AtomicInteger rangeRequests = new AtomicInteger();
     private final AtomicReference<String> lastRangeHeader = new AtomicReference<>();
     private final AtomicReference<String> lastIfRangeHeader = new AtomicReference<>();
     private final AtomicInteger count206 = new AtomicInteger();
@@ -125,6 +126,7 @@ public class HttpRangeResumeIT {
 
     private void resetCaptures() {
         jarGets.set(0);
+        rangeRequests.set(0);
         lastRangeHeader.set(null);
         lastIfRangeHeader.set(null);
         count206.set(0);
@@ -289,13 +291,13 @@ public class HttpRangeResumeIT {
     }
 
     /**
-     * With {@code deployment.http.range.resume=false} the client must never send a Range
+     * With {@code deployment.http.range.enabled=false} the client must never send a Range
      * header, so even a Range-capable server serves a plain 200 full download and the
      * truncated cache is replaced. Guards the config escape hatch end-to-end.
      */
     @Test
     void rangeDisabledDoesFullGetOnly() throws Exception {
-        writeUserDeploymentProperty("deployment.http.range.resume", "false");
+        writeUserDeploymentProperty("deployment.http.range.enabled", "false");
         mode = RangeMode.HONOR;
 
         Path marker1 = markerDir.resolve("success1.marker");
@@ -361,6 +363,35 @@ public class HttpRangeResumeIT {
         assertEquals(fullJar.length, Files.size(replaced),
                 "mismatch fallback full GET must restore full length");
         assertArrayEquals(fullJar, Files.readAllBytes(replaced));
+    }
+
+    /**
+     * With a tiny {@code deployment.http.range.maxSlotBytes} a fresh large download is split
+     * into many parallel Range chunks (probe + workers), fetched concurrently and reassembled
+     * into a byte-identical, signature-verifiable jar that then launches. Proves the multipart
+     * split path end-to-end against a real {@code javaws}.
+     */
+    @Test
+    void multipartRangeSplitsReassemblesAndLaunches() throws Exception {
+        writeUserDeploymentProperty("deployment.http.range.maxSlotBytes", "64");
+        mode = RangeMode.HONOR;
+
+        Path marker1 = markerDir.resolve("success1.marker");
+        writeJnlp(marker1);
+        LaunchResult first = launch(marker1);
+        assertTrue(first.success, "multipart launch must reassemble and succeed:\n" + first.output);
+        assertFalse(first.output.contains("ZipException"),
+                "reassembled jar must not fail signature/zip checks:\n" + first.output);
+
+        // Many Range requests (probe + ceil(len/64) - 1 chunks) prove the file was actually split.
+        assertTrue(rangeRequests.get() > 1,
+                "expected multiple parallel Range chunk requests, saw " + rangeRequests.get());
+        assertTrue(count206.get() > 1, "each chunk is served as 206");
+
+        Path cachedJar = findCachedJar(cacheHome, JAR_NAME);
+        assertNotNull(cachedJar, "reassembled jar must be cached");
+        assertEquals(fullJar.length, Files.size(cachedJar), "reassembled length must equal original");
+        assertArrayEquals(fullJar, Files.readAllBytes(cachedJar));
     }
 
     // ----- helpers -----
@@ -565,6 +596,7 @@ public class HttpRangeResumeIT {
             jarGets.incrementAndGet();
             String rangeHeader = exchange.getRequestHeaders().getFirst(Headers.RANGE);
             if (rangeHeader != null) {
+                rangeRequests.incrementAndGet();
                 lastRangeHeader.set(rangeHeader);
             }
             String ifRange = exchange.getRequestHeaders().getFirst(Headers.IF_RANGE);
@@ -600,20 +632,20 @@ public class HttpRangeResumeIT {
                     break;
             }
 
-            long start = parseRangeStart(rangeHeader, body.length);
+            long[] range = parseRange(rangeHeader, body.length);
             if (mode == RangeMode.MISMATCH) {
                 // Claim the suffix starts at 0 so it cannot line up with the requested offset.
                 count206.incrementAndGet();
                 servePartial(exchange, body, 0, body.length - 1);
                 return;
             }
-            if (start < 0 || start >= body.length) {
+            if (range == null) {
                 count416.incrementAndGet();
                 rejectRange(exchange, body.length);
                 return;
             }
             count206.incrementAndGet();
-            servePartial(exchange, body, start, body.length - 1);
+            servePartial(exchange, body, range[0], range[1]);
         }
 
         private void serveFull(HttpServerExchange exchange, byte[] body) {
@@ -667,11 +699,16 @@ public class HttpRangeResumeIT {
             }
         }
 
-        private long parseRangeStart(String rangeHeader, int length) {
+        /**
+         * Parse a single byte range into {@code [start, end]} (inclusive). Supports the bounded
+         * {@code bytes=start-end} and open-ended {@code bytes=start-} forms used by ITW. Suffix
+         * form and unsatisfiable ranges return {@code null} (caller emits 416).
+         */
+        private long[] parseRange(String rangeHeader, int length) {
             String h = rangeHeader.trim();
             int eq = h.indexOf('=');
             if (eq == -1 || !h.substring(0, eq).trim().equalsIgnoreCase("bytes")) {
-                return -1;
+                return null;
             }
             String spec = h.substring(eq + 1).trim();
             int comma = spec.indexOf(',');
@@ -680,16 +717,25 @@ public class HttpRangeResumeIT {
             }
             int dash = spec.indexOf('-');
             if (dash == -1) {
-                return -1;
+                return null;
             }
-            String start = spec.substring(0, dash).trim();
+            String s = spec.substring(0, dash).trim();
+            String e = spec.substring(dash + 1).trim();
             try {
-                if (start.isEmpty()) {
-                    return -1; // suffix form not used by ITW resume requests
+                if (s.isEmpty()) {
+                    return null; // suffix form not used by ITW resume/multipart requests
                 }
-                return Long.parseLong(start);
-            } catch (NumberFormatException e) {
-                return -1;
+                long start = Long.parseLong(s);
+                long end = e.isEmpty() ? length - 1L : Long.parseLong(e);
+                if (length <= 0 || start >= length || start > end) {
+                    return null;
+                }
+                if (end >= length) {
+                    end = length - 1L;
+                }
+                return new long[]{start, end};
+            } catch (NumberFormatException ex) {
+                return null;
             }
         }
     }

--- a/netx/net/sourceforge/jnlp/cache/MultipartRangeDownloader.java
+++ b/netx/net/sourceforge/jnlp/cache/MultipartRangeDownloader.java
@@ -40,6 +40,16 @@ final class MultipartRangeDownloader {
 
     /** Cap on concurrent chunk fetches (chunk count can be higher; extra chunks queue). */
     private static final int MAX_PARALLEL = 8;
+    /**
+     * Shared daemon pool for ALL multipart chunk fetches across all resources, so concurrent
+     * splits can't multiply into one-threadpool-per-download (which would overrun the HTTP
+     * connection pool's per-route limit). Sized below the default maxPerRoute (12).
+     */
+    private static final ExecutorService CHUNK_POOL = Executors.newFixedThreadPool(MAX_PARALLEL, r -> {
+        Thread t = new Thread(r, "itw-multipart-range");
+        t.setDaemon(true);
+        return t;
+    });
     /** Safety valve against pathological slot sizes (e.g. a few-byte slot on a huge file). */
     private static final int MAX_CHUNKS = 100_000;
     /** Per-chunk retries on a transient failure before aborting the whole transfer. */
@@ -94,7 +104,6 @@ final class MultipartRangeDownloader {
         File[] parts = new File[n];
         long[] written = new long[n];
 
-        ExecutorService pool = null;
         boolean success = false;
         try {
             // Chunk 0: drain the already-fetched probe response — unless a prior attempt already
@@ -119,12 +128,6 @@ final class MultipartRangeDownloader {
             }
 
             if (n > 1) {
-                int parallel = Math.min(MAX_PARALLEL, n - 1);
-                pool = Executors.newFixedThreadPool(parallel, r -> {
-                    Thread t = new Thread(r, "itw-multipart-range");
-                    t.setDaemon(true);
-                    return t;
-                });
                 List<Future<Long>> futures = new ArrayList<>();
                 List<Integer> submitted = new ArrayList<>();
                 for (int i = 1; i < n; i++) {
@@ -142,7 +145,7 @@ final class MultipartRangeDownloader {
                         continue;
                     }
                     submitted.add(idx);
-                    futures.add(pool.submit(() -> fetchChunk(idx, part)));
+                    futures.add(CHUNK_POOL.submit(() -> fetchChunk(idx, part)));
                 }
                 for (int j = 0; j < futures.size(); j++) {
                     int idx = submitted.get(j);
@@ -174,14 +177,7 @@ final class MultipartRangeDownloader {
             deleteCorruptLocal(dest);
             throw (e instanceof IOException) ? (IOException) e : new IOException("Multipart download failed", e);
         } finally {
-            if (pool != null) {
-                pool.shutdownNow();
-                try {
-                    pool.awaitTermination(2, TimeUnit.SECONDS);
-                } catch (InterruptedException ignored) {
-                    Thread.currentThread().interrupt();
-                }
-            }
+            // CHUNK_POOL is shared and long-lived; never shut it down here.
             // Keep the parts on a transfer failure so a retry resumes from them; clean up only
             // once the full file has been reassembled successfully.
             if (success) {

--- a/netx/net/sourceforge/jnlp/cache/MultipartRangeDownloader.java
+++ b/netx/net/sourceforge/jnlp/cache/MultipartRangeDownloader.java
@@ -42,6 +42,10 @@ final class MultipartRangeDownloader {
     private static final int MAX_PARALLEL = 8;
     /** Safety valve against pathological slot sizes (e.g. a few-byte slot on a huge file). */
     private static final int MAX_CHUNKS = 100_000;
+    /** Per-chunk retries on a transient failure before aborting the whole transfer. */
+    private static final int CHUNK_RETRIES = 2;
+    /** Base backoff (ms) between chunk retries; scaled by attempt number. */
+    private static final long CHUNK_RETRY_DELAY_MS = 500L;
 
     private final URL url;
     private final long totalLength;
@@ -76,11 +80,12 @@ final class MultipartRangeDownloader {
     }
 
     private File run(HttpResponse firstResponse) throws IOException {
-        int n = Math.max(1, (int) ((totalLength + slotSize - 1) / slotSize));
-        if (n > MAX_CHUNKS) {
-            throw new IOException("Refusing multipart download: " + n
+        long nLong = Math.max(1L, (totalLength + slotSize - 1) / slotSize);
+        if (nLong > MAX_CHUNKS) {
+            throw new IOException("Refusing multipart download: " + nLong
                     + " chunks exceeds limit (slotSize=" + slotSize + ", total=" + totalLength + ")");
         }
+        int n = (int) nLong;
         if (!tmpDir.mkdirs() && !tmpDir.isDirectory()) {
             throw new IOException("Cannot create multipart temp dir: " + tmpDir);
         }
@@ -159,7 +164,32 @@ final class MultipartRangeDownloader {
         }
     }
 
+    /**
+     * Fetch one chunk, retrying transient failures (a dropped connection mid-chunk is exactly
+     * what Range resume exists for). A persistent failure re-throws after {@link #CHUNK_RETRIES}
+     * attempts so the caller can abort the whole transfer and fall back to a full GET.
+     */
     private long fetchChunk(int idx, File part) throws IOException {
+        IOException last = null;
+        for (int attempt = 0; attempt <= CHUNK_RETRIES; attempt++) {
+            try {
+                return fetchChunkOnce(idx, part);
+            } catch (IOException e) {
+                last = e;
+                if (attempt < CHUNK_RETRIES) {
+                    try {
+                        Thread.sleep(CHUNK_RETRY_DELAY_MS * (attempt + 1));
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                        throw new IOException("Interrupted retrying multipart chunk " + idx, ie);
+                    }
+                }
+            }
+        }
+        throw last;
+    }
+
+    private long fetchChunkOnce(int idx, File part) throws IOException {
         long start = (long) idx * slotSize;
         long end = Math.min(start + slotSize - 1, totalLength - 1);
         Map<String, String> headers = new HashMap<>();

--- a/netx/net/sourceforge/jnlp/cache/MultipartRangeDownloader.java
+++ b/netx/net/sourceforge/jnlp/cache/MultipartRangeDownloader.java
@@ -63,8 +63,9 @@ final class MultipartRangeDownloader {
         this.ifRangeMillis = ifRangeMillis;
         this.resource = resource;
         this.dest = dest;
-        this.tmpDir = new File(dest.getParentFile(),
-                dest.getName() + ".multipart-" + Long.toHexString(System.nanoTime()));
+        // Deterministic name so a retried/aborted transfer resumes from the parts already on
+        // disk instead of re-fetching every chunk.
+        this.tmpDir = new File(dest.getParentFile(), dest.getName() + ".multipart");
     }
 
     /**
@@ -94,15 +95,22 @@ final class MultipartRangeDownloader {
         long[] written = new long[n];
 
         ExecutorService pool = null;
+        boolean success = false;
         try {
-            // Chunk 0: drain the already-fetched probe response.
+            // Chunk 0: drain the already-fetched probe response — unless a prior attempt already
+            // left a complete part-0 on disk, in which case the probe body is discarded.
             parts[0] = new File(tmpDir, "part-0");
             if (slot != null) {
                 slot.onFirstByte(System.currentTimeMillis());
             }
-            written[0] = drainToPart(firstResponse.getBody(), parts[0]);
-            firstResponse.close();
-            verifyChunk(0, written[0]);
+            if (parts[0].isFile() && parts[0].length() == expectedChunkLength(0)) {
+                firstResponse.close();
+                written[0] = parts[0].length();
+            } else {
+                written[0] = drainToPart(firstResponse.getBody(), parts[0]);
+                firstResponse.close();
+                verifyChunk(0, written[0]);
+            }
 
             long running = written[0];
             resource.setTransferred(running);
@@ -118,20 +126,33 @@ final class MultipartRangeDownloader {
                     return t;
                 });
                 List<Future<Long>> futures = new ArrayList<>();
+                List<Integer> submitted = new ArrayList<>();
                 for (int i = 1; i < n; i++) {
                     final int idx = i;
                     final File part = new File(tmpDir, "part-" + idx);
                     parts[idx] = part;
+                    // Resume: skip chunks a prior attempt already wrote completely.
+                    if (part.isFile() && part.length() == expectedChunkLength(idx)) {
+                        written[idx] = part.length();
+                        running += written[idx];
+                        resource.setTransferred(running);
+                        if (slot != null) {
+                            slot.addTransferred(written[idx]);
+                        }
+                        continue;
+                    }
+                    submitted.add(idx);
                     futures.add(pool.submit(() -> fetchChunk(idx, part)));
                 }
-                for (int i = 1; i < n; i++) {
+                for (int j = 0; j < futures.size(); j++) {
+                    int idx = submitted.get(j);
                     // Blocking get re-throws the worker's IOException wrapped in ExecutionException.
-                    written[i] = futures.get(i - 1).get();
-                    verifyChunk(i, written[i]);
-                    running += written[i];
+                    written[idx] = futures.get(j).get();
+                    verifyChunk(idx, written[idx]);
+                    running += written[idx];
                     resource.setTransferred(running); // single-threaded, progressive progress
                     if (slot != null) {
-                        slot.addTransferred(written[i]);
+                        slot.addTransferred(written[idx]);
                     }
                 }
             }
@@ -147,6 +168,7 @@ final class MultipartRangeDownloader {
             OutputController.getLogger().log(OutputController.Level.MESSAGE_DEBUG,
                     "Multipart range download complete: " + n + " chunks, " + totalLength
                             + " bytes from " + url);
+            success = true;
             return dest;
         } catch (Exception e) {
             deleteCorruptLocal(dest);
@@ -160,7 +182,26 @@ final class MultipartRangeDownloader {
                     Thread.currentThread().interrupt();
                 }
             }
-            deleteRecursive(tmpDir);
+            // Keep the parts on a transfer failure so a retry resumes from them; clean up only
+            // once the full file has been reassembled successfully.
+            if (success) {
+                deleteRecursive(tmpDir);
+            }
+        }
+    }
+
+    /**
+     * Remove any stale multipart parts for a resource (used when the resource is downloaded by
+     * a non-multipart path — single GET, resume suffix, pack200 — so an abandoned split does not
+     * leave orphan part files behind). No-op when no parts directory exists.
+     */
+    static void cleanupStaleParts(File dest) {
+        if (dest == null) {
+            return;
+        }
+        File dir = new File(dest.getParentFile(), dest.getName() + ".multipart");
+        if (dir.isDirectory()) {
+            deleteRecursive(dir);
         }
     }
 

--- a/netx/net/sourceforge/jnlp/cache/MultipartRangeDownloader.java
+++ b/netx/net/sourceforge/jnlp/cache/MultipartRangeDownloader.java
@@ -1,0 +1,265 @@
+package net.sourceforge.jnlp.cache;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import net.sourceforge.jnlp.cache.download.ConnectionTiming;
+import net.sourceforge.jnlp.security.HttpClientProvider;
+import net.sourceforge.jnlp.security.HttpResponse;
+import net.sourceforge.jnlp.util.logging.OutputController;
+
+/**
+ * Multipart parallel-range download of a single large resource (RFC 7233). The first chunk
+ * (the probe response, already fetched by {@link ResourceDownloader}) is consumed here; the
+ * remaining chunks are fetched concurrently and every chunk is drained to its own temp part
+ * file, then concatenated in order into the destination cache file. A server that does not
+ * return a satisfiable 206 for a chunk aborts the whole transfer (the caller retries / falls
+ * back to a full GET).
+ * <p>
+ * Only identity (uncompressed) resources are eligible; pack200-gzip / gzip are handled by the
+ * single-stream path. Integrity (jar signature/digest) is verified afterwards by the caller's
+ * settle-good gate on the reassembled file.
+ */
+final class MultipartRangeDownloader {
+
+    /** Cap on concurrent chunk fetches (chunk count can be higher; extra chunks queue). */
+    private static final int MAX_PARALLEL = 8;
+    /** Safety valve against pathological slot sizes (e.g. a few-byte slot on a huge file). */
+    private static final int MAX_CHUNKS = 100_000;
+
+    private final URL url;
+    private final long totalLength;
+    private final long slotSize;
+    private final long ifRangeMillis;
+    private final Resource resource;
+    private final File dest;
+    private final File tmpDir;
+
+    private MultipartRangeDownloader(URL url, long totalLength, long slotSize, long ifRangeMillis,
+            Resource resource, File dest) {
+        this.url = url;
+        this.totalLength = totalLength;
+        this.slotSize = slotSize;
+        this.ifRangeMillis = ifRangeMillis;
+        this.resource = resource;
+        this.dest = dest;
+        this.tmpDir = new File(dest.getParentFile(),
+                dest.getName() + ".multipart-" + Long.toHexString(System.nanoTime()));
+    }
+
+    /**
+     * Consume {@code firstResponse} as chunk 0, fetch the remaining chunks in parallel, and
+     * reassemble into {@code dest}. Returns {@code dest} (the fully-written file). The caller
+     * must NOT close {@code firstResponse} afterwards (it is closed here).
+     */
+    static File download(HttpResponse firstResponse, URL url, long totalLength, long slotSize,
+            Resource resource, File dest) throws IOException {
+        long ifRange = firstResponse.getLastModified();
+        MultipartRangeDownloader d = new MultipartRangeDownloader(url, totalLength, slotSize, ifRange, resource, dest);
+        return d.run(firstResponse);
+    }
+
+    private File run(HttpResponse firstResponse) throws IOException {
+        int n = Math.max(1, (int) ((totalLength + slotSize - 1) / slotSize));
+        if (n > MAX_CHUNKS) {
+            throw new IOException("Refusing multipart download: " + n
+                    + " chunks exceeds limit (slotSize=" + slotSize + ", total=" + totalLength + ")");
+        }
+        if (!tmpDir.mkdirs() && !tmpDir.isDirectory()) {
+            throw new IOException("Cannot create multipart temp dir: " + tmpDir);
+        }
+        net.sourceforge.jnlp.cache.download.JarSlot slot = resource.getJarSlot();
+        File[] parts = new File[n];
+        long[] written = new long[n];
+
+        ExecutorService pool = null;
+        try {
+            // Chunk 0: drain the already-fetched probe response.
+            parts[0] = new File(tmpDir, "part-0");
+            if (slot != null) {
+                slot.onFirstByte(System.currentTimeMillis());
+            }
+            written[0] = drainToPart(firstResponse.getBody(), parts[0]);
+            firstResponse.close();
+            verifyChunk(0, written[0]);
+
+            long running = written[0];
+            resource.setTransferred(running);
+            if (slot != null) {
+                slot.addTransferred(running);
+            }
+
+            if (n > 1) {
+                int parallel = Math.min(MAX_PARALLEL, n - 1);
+                pool = Executors.newFixedThreadPool(parallel, r -> {
+                    Thread t = new Thread(r, "itw-multipart-range");
+                    t.setDaemon(true);
+                    return t;
+                });
+                List<Future<Long>> futures = new ArrayList<>();
+                for (int i = 1; i < n; i++) {
+                    final int idx = i;
+                    final File part = new File(tmpDir, "part-" + idx);
+                    parts[idx] = part;
+                    futures.add(pool.submit(() -> fetchChunk(idx, part)));
+                }
+                for (int i = 1; i < n; i++) {
+                    // Blocking get re-throws the worker's IOException wrapped in ExecutionException.
+                    written[i] = futures.get(i - 1).get();
+                    verifyChunk(i, written[i]);
+                    running += written[i];
+                    resource.setTransferred(running); // single-threaded, progressive progress
+                    if (slot != null) {
+                        slot.addTransferred(written[i]);
+                    }
+                }
+            }
+
+            concatenate(parts, dest);
+            if (slot != null) {
+                slot.onLastByte(System.currentTimeMillis());
+            }
+            if (dest.length() != totalLength) {
+                throw new IOException("Multipart reassembly produced " + dest.length()
+                        + " bytes, expected " + totalLength);
+            }
+            OutputController.getLogger().log(OutputController.Level.MESSAGE_DEBUG,
+                    "Multipart range download complete: " + n + " chunks, " + totalLength
+                            + " bytes from " + url);
+            return dest;
+        } catch (Exception e) {
+            deleteCorruptLocal(dest);
+            throw (e instanceof IOException) ? (IOException) e : new IOException("Multipart download failed", e);
+        } finally {
+            if (pool != null) {
+                pool.shutdownNow();
+                try {
+                    pool.awaitTermination(2, TimeUnit.SECONDS);
+                } catch (InterruptedException ignored) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+            deleteRecursive(tmpDir);
+        }
+    }
+
+    private long fetchChunk(int idx, File part) throws IOException {
+        long start = (long) idx * slotSize;
+        long end = Math.min(start + slotSize - 1, totalLength - 1);
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Accept-Encoding", "identity");
+        headers.put("Range", "bytes=" + start + "-" + end);
+        if (ifRangeMillis > 0) {
+            String ifRange = ResourceDownloader.formatIfRangeDate(ifRangeMillis);
+            if (ifRange != null) {
+                headers.put("If-Range", ifRange);
+            }
+        }
+        ConnectionTiming timing = new ConnectionTiming();
+        try (HttpResponse r = HttpClientProvider.getDefault().open(url, "GET", headers, timing)) {
+            int status = r.getStatusCode();
+            if (status != HttpURLConnection.HTTP_PARTIAL) {
+                throw new IOException("Multipart chunk " + idx + " expected 206, got " + status);
+            }
+            long[] cr = ResourceDownloader.parseContentRange(r.getHeader("Content-Range"));
+            if (cr == null || cr[0] != start || (cr[2] >= 0 && cr[2] != totalLength)) {
+                throw new IOException("Multipart chunk " + idx + " Content-Range mismatch: "
+                        + r.getHeader("Content-Range"));
+            }
+            return drainToPart(r.getBody(), part);
+        }
+    }
+
+    private void verifyChunk(int idx, long bytesWritten) throws IOException {
+        long expected = expectedChunkLength(idx);
+        if (bytesWritten != expected) {
+            throw new IOException("Multipart chunk " + idx + " wrote " + bytesWritten
+                    + " bytes, expected " + expected);
+        }
+    }
+
+    private long expectedChunkLength(int idx) {
+        long start = (long) idx * slotSize;
+        long end = Math.min(start + slotSize - 1, totalLength - 1);
+        return end - start + 1;
+    }
+
+    private static long drainToPart(InputStream in, File part) throws IOException {
+        File parent = part.getParentFile();
+        if (parent != null && !parent.isDirectory() && !parent.mkdirs()) {
+            throw new IOException("Cannot create multipart part dir: " + parent);
+        }
+        byte[] buf = new byte[8192];
+        long total = 0;
+        int rlen;
+        try (OutputStream out = new BufferedOutputStream(new FileOutputStream(part))) {
+            while (-1 != (rlen = in.read(buf))) {
+                out.write(buf, 0, rlen);
+                total += rlen;
+            }
+        }
+        return total;
+    }
+
+    private static void concatenate(File[] parts, File dest) throws IOException {
+        File parent = dest.getParentFile();
+        if (parent != null && !parent.isDirectory() && !parent.mkdirs()) {
+            throw new IOException("Cannot create cache dir for reassembly: " + parent);
+        }
+        byte[] buf = new byte[8192];
+        int rlen;
+        try (OutputStream out = new BufferedOutputStream(new FileOutputStream(dest))) {
+            for (File part : parts) {
+                try (InputStream in = new BufferedInputStream(new FileInputStream(part))) {
+                    while (-1 != (rlen = in.read(buf))) {
+                        out.write(buf, 0, rlen);
+                    }
+                }
+            }
+        }
+    }
+
+    private static void deleteRecursive(File root) {
+        if (root == null || !root.exists()) {
+            return;
+        }
+        File[] files = root.listFiles();
+        if (files != null) {
+            for (File f : files) {
+                if (f.isDirectory()) {
+                    deleteRecursive(f);
+                } else {
+                    f.delete();
+                }
+            }
+        }
+        root.delete();
+    }
+
+    private static void deleteCorruptLocal(File local) {
+        if (local == null || !local.isFile()) {
+            return;
+        }
+        try {
+            java.nio.file.Files.deleteIfExists(local.toPath());
+        } catch (IOException deleteEx) {
+            OutputController.getLogger().log(deleteEx);
+        }
+    }
+}

--- a/netx/net/sourceforge/jnlp/cache/ResourceDownloader.java
+++ b/netx/net/sourceforge/jnlp/cache/ResourceDownloader.java
@@ -192,12 +192,27 @@ public class ResourceDownloader implements Runnable {
     }
 
     /**
-     * Whether HTTP Range (RFC 7233) resume of interrupted downloads is enabled
-     * ({@code deployment.http.range.resume}, default true).
+     * Whether HTTP Range (RFC 7233) is enabled ({@code deployment.http.range.enabled},
+     * default true). Gates both resume of interrupted downloads and the multipart split of
+     * large fresh downloads.
      */
-    private static boolean isRangeResumeEnabled() {
+    private static boolean isRangeEnabled() {
         return Boolean.valueOf(JNLPRuntime.getConfiguration().getProperty(
-                DeploymentConfiguration.KEY_HTTP_RANGE_RESUME));
+                DeploymentConfiguration.KEY_HTTP_RANGE_ENABLED));
+    }
+
+    /**
+     * Maximum byte size of each parallel Range chunk for a fresh large download
+     * ({@code deployment.http.range.maxSlotBytes}, default 50&nbsp;MB). {@code 0} disables
+     * the multipart split (resume still works).
+     */
+    private static long getRangeMaxSlotBytes() {
+        try {
+            return Long.parseLong(JNLPRuntime.getConfiguration().getProperty(
+                    DeploymentConfiguration.KEY_HTTP_RANGE_MAX_SLOT_BYTES));
+        } catch (Exception e) {
+            return 0L;
+        }
     }
 
     /**
@@ -615,11 +630,20 @@ public class ResourceDownloader implements Runnable {
         net.sourceforge.jnlp.security.HttpResponse response = null;
         URL downloadFrom = null;
 
-        // HTTP Range (RFC 7233) resume: when a partial cache file exists, ask the server
-        // for only the missing suffix. effectiveResume is zeroed whenever a server forces
-        // a full GET fallback (416, mismatched Content-Range, or a compressed representation).
+        // HTTP Range (RFC 7233): either resume an interrupted download (a partial cache file
+        // exists → request the missing suffix) or split a large fresh download into parallel
+        // chunks. effectiveResume is zeroed whenever a server forces a full GET fallback.
         ResumeTarget resume = computeResumeTarget();
         long effectiveResume = resume.offset;
+        final URL rangeLoc = resource.getLocation();
+        final long slotSize = getRangeMaxSlotBytes();
+        final boolean multipartEligible = effectiveResume == 0
+                && slotSize > 0
+                && isRangeEnabled()
+                && ("http".equalsIgnoreCase(rangeLoc.getProtocol())
+                        || "https".equalsIgnoreCase(rangeLoc.getProtocol()))
+                && !rangeLoc.getPath().toLowerCase().endsWith(".pack.gz");
+        String probeHeader = multipartEligible ? multipartProbeHeader(slotSize) : null;
 
         try {
             // When skipHeadIfNotCached set up URL candidates during initialize,
@@ -633,17 +657,21 @@ public class ResourceDownloader implements Runnable {
             IOException lastError = null;
             for (URL candidate : tryUrls) {
                 try {
-                    response = getDownloadConnection(candidate, effectiveResume, resume.ifRangeLastModified);
+                    String rangeHeader = effectiveResume > 0 ? buildRangeHeader(effectiveResume) : probeHeader;
+                    response = getDownloadConnection(candidate, rangeHeader, resume.ifRangeLastModified);
                     int status = response.getStatusCode();
-                    if (effectiveResume > 0 && isRangeRejection(response, status, effectiveResume)) {
-                        // Server could not honour the suffix (416) or returned a 206 whose
-                        // Content-Range does not line up with the on-disk prefix. Fall back
-                        // to a full GET on the same candidate.
-                        logResourceDebug(downloadTo, "Range resume rejected (" + status
+                    long requestedStart = effectiveResume > 0 ? effectiveResume : 0L;
+                    if (rangeHeader != null && isRangeRejection(response, status, requestedStart)) {
+                        // Server rejected the Range (416) or returned a 206 whose Content-Range
+                        // does not line up with the requested offset. Applies to both a resume
+                        // suffix and a multipart probe. Fall back to a full GET on the same
+                        // candidate and stop probing remaining candidates.
+                        logResourceDebug(downloadTo, "Range request rejected (" + status
                                 + ") for " + candidate + " - falling back to full GET");
                         response.close();
-                        response = getDownloadConnection(candidate, 0L, 0L);
+                        response = getDownloadConnection(candidate, null, 0L);
                         effectiveResume = 0L;
+                        probeHeader = null;
                         status = response.getStatusCode();
                     }
                     // HTTP error codes (404 etc.) are not exceptions; check the
@@ -685,34 +713,55 @@ public class ResourceDownloader implements Runnable {
             String contentEncoding = response.getContentEncoding();
             int status = response.getStatusCode();
 
-            // Only an identity (uncompressed) 206 whose Content-Range lined up with the
-            // on-disk prefix is byte-resumable. pack200-gzip / gzip bodies are not.
+            // It's important to check packgz first. If a stream is both
+            // pack200 and gz encoded, then the Content-Encoding could
+            // return ".gz", so if we check gzip first, we would end up
+            // treating a pack200 file as a jar file.
             boolean packgz = "pack200-gzip".equals(contentEncoding)
                     || downloadFrom.getPath().endsWith(".pack.gz");
             boolean gzip = "gzip".equals(contentEncoding);
+
+            // Only an identity (uncompressed) 206 whose Content-Range lined up with the
+            // on-disk prefix is byte-resumable. pack200-gzip / gzip bodies are not.
             boolean rangeHonored = status == HttpURLConnection.HTTP_PARTIAL && effectiveResume > 0
                     && !packgz && !gzip;
             // On a 206 the Content-Length is only the slice; report the full size for progress.
-            if (rangeHonored) {
+            if (status == HttpURLConnection.HTTP_PARTIAL) {
                 long total = parseContentRangeTotal(response.getHeader("Content-Range"));
                 if (total > 0) {
                     resource.setSize(total);
                 }
             }
 
+            // Multipart split: a probe Range (bytes=0-(slotSize-1)) was sent on a fresh
+            // identity download and the server answered 206. Only split when the resource is
+            // larger than one slot; otherwise the 206 already carried the whole body.
+            long multipartTotal = -1L;
+            boolean multipart = multipartEligible
+                    && status == HttpURLConnection.HTTP_PARTIAL
+                    && !packgz && !gzip
+                    && (multipartTotal = parseContentRangeTotal(response.getHeader("Content-Range"))) > slotSize;
+
             logResourceDebug(downloadTo, "Downloading " + downloadTo + " using "
                     + downloadFrom + " (encoding : " + contentEncoding
-                    + (rangeHonored ? ", range resume from " + effectiveResume : "") + ") ");
+                    + (rangeHonored ? ", range resume from " + effectiveResume : "")
+                    + (multipart ? ", multipart " + multipartTotal + "B slot " + slotSize + "B" : "") + ") ");
 
-            // It's important to check packgz first. If a stream is both
-            // pack200 and gz encoded, then the Content-Encoding could
-            // return ".gz", so if we check gzip first, we would end up
-            // treating a pack200 file as a jar file.
             if (packgz) {
                 CachedDaemonThreadPoolProvider.notePackGzDetected();
                 downloadPackGzFileDirectly(response, downloadFrom, downloadTo);
             } else if (gzip) {
                 downloadGZipFile(response, downloadFrom, downloadTo);
+            } else if (multipart) {
+                long lastModified = response.getLastModified();
+                CacheEntry entry = new CacheEntry(downloadTo, resource.getDownloadVersion());
+                File dest = entry.getCacheFile();
+                // download() consumes/closes the probe response as chunk 0 and reassembles into dest.
+                File reassembled = MultipartRangeDownloader.download(
+                        response, downloadFrom, multipartTotal, slotSize, resource, dest);
+                response = null; // ownership transferred (closed inside download())
+                resource.setLocalFile(reassembled);
+                storeEntryFields(entry, reassembled.length(), lastModified);
             } else {
                 downloadFile(response, downloadTo, false, null, rangeHonored,
                         rangeHonored ? effectiveResume : 0L);
@@ -757,7 +806,7 @@ public class ResourceDownloader implements Runnable {
      */
     private ResumeTarget computeResumeTarget() {
         URL loc = resource.getLocation();
-        if (!isRangeResumeEnabled()) {
+        if (!isRangeEnabled()) {
             return ResumeTarget.NONE;
         }
         String protocol = loc.getProtocol();
@@ -793,17 +842,16 @@ public class ResourceDownloader implements Runnable {
     }
 
     private net.sourceforge.jnlp.security.HttpResponse getDownloadConnection(URL location) throws IOException {
-        return getDownloadConnection(location, 0L, 0L);
+        return getDownloadConnection(location, null, 0L);
     }
 
-    private net.sourceforge.jnlp.security.HttpResponse getDownloadConnection(URL location, long rangeFrom, long ifRangeLastModified)
+    private net.sourceforge.jnlp.security.HttpResponse getDownloadConnection(URL location, String rangeHeader, long ifRangeLastModified)
             throws IOException {
         java.util.Map<String, String> headers = new java.util.HashMap<>();
         headers.put("Accept-Encoding", getAcceptEncoding());
-        // Resume an interrupted download by asking for the missing suffix (RFC 7233).
-        // If-Range makes the server return the full 200 representation when the resource
-        // has changed, so a stale prefix is never appended to.
-        String rangeHeader = buildRangeHeader(rangeFrom);
+        // Resume / multipart-split send a Range header (RFC 7233). If-Range makes the server
+        // return the full 200 representation when the resource has changed, so a stale prefix
+        // is never appended to and parallel chunks refer to a single version.
         if (rangeHeader != null) {
             headers.put("Range", rangeHeader);
             String ifRange = formatIfRangeDate(ifRangeLastModified);
@@ -821,6 +869,11 @@ public class ResourceDownloader implements Runnable {
             slot.onConnect(start, end, timing.reused);
         }
         return response;
+    }
+
+    /** Build a bounded Range header for the multipart probe / first chunk: {@code bytes=0-(slotSize-1)}. */
+    private static String multipartProbeHeader(long slotSize) {
+        return "bytes=0-" + (slotSize - 1);
     }
 
     /** Package-visible for Groovy probes / unit tests. */

--- a/netx/net/sourceforge/jnlp/cache/ResourceDownloader.java
+++ b/netx/net/sourceforge/jnlp/cache/ResourceDownloader.java
@@ -16,6 +16,9 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.EnumSet;
 import java.util.Collections;
 import java.util.HashMap;
@@ -186,6 +189,15 @@ public class ResourceDownloader implements Runnable {
     private static boolean isSkipHeadIfNotCached() {
         return Boolean.valueOf(JNLPRuntime.getConfiguration().getProperty(
                 DeploymentConfiguration.KEY_HTTP_SKIP_HEAD_IF_NOT_CACHED));
+    }
+
+    /**
+     * Whether HTTP Range (RFC 7233) resume of interrupted downloads is enabled
+     * ({@code deployment.http.range.resume}, default true).
+     */
+    private static boolean isRangeResumeEnabled() {
+        return Boolean.valueOf(JNLPRuntime.getConfiguration().getProperty(
+                DeploymentConfiguration.KEY_HTTP_RANGE_RESUME));
     }
 
     /**
@@ -603,6 +615,12 @@ public class ResourceDownloader implements Runnable {
         net.sourceforge.jnlp.security.HttpResponse response = null;
         URL downloadFrom = null;
 
+        // HTTP Range (RFC 7233) resume: when a partial cache file exists, ask the server
+        // for only the missing suffix. effectiveResume is zeroed whenever a server forces
+        // a full GET fallback (416, mismatched Content-Range, or a compressed representation).
+        ResumeTarget resume = computeResumeTarget();
+        long effectiveResume = resume.offset;
+
         try {
             // When skipHeadIfNotCached set up URL candidates during initialize,
             // try each with a GET. The first successful GET IS the download
@@ -615,11 +633,23 @@ public class ResourceDownloader implements Runnable {
             IOException lastError = null;
             for (URL candidate : tryUrls) {
                 try {
-                    response = getDownloadConnection(candidate);
+                    response = getDownloadConnection(candidate, effectiveResume, resume.ifRangeLastModified);
+                    int status = response.getStatusCode();
+                    if (effectiveResume > 0 && isRangeRejection(response, status, effectiveResume)) {
+                        // Server could not honour the suffix (416) or returned a 206 whose
+                        // Content-Range does not line up with the on-disk prefix. Fall back
+                        // to a full GET on the same candidate.
+                        logResourceDebug(downloadTo, "Range resume rejected (" + status
+                                + ") for " + candidate + " - falling back to full GET");
+                        response.close();
+                        response = getDownloadConnection(candidate, 0L, 0L);
+                        effectiveResume = 0L;
+                        status = response.getStatusCode();
+                    }
                     // HTTP error codes (404 etc.) are not exceptions; check the
                     // status explicitly to fall through to the next candidate.
-                    if (response.getStatusCode() >= 400) {
-                        logResourceDebug(downloadTo, "GET returned " + response.getStatusCode()
+                    if (status >= 400) {
+                        logResourceDebug(downloadTo, "GET returned " + status
                                 + " for " + candidate + ", trying next URL candidate");
                         ResourceUrlCreator.notePackHost(candidate, false);
                         response.close();
@@ -653,13 +683,26 @@ public class ResourceDownloader implements Runnable {
             }
 
             String contentEncoding = response.getContentEncoding();
+            int status = response.getStatusCode();
 
-            logResourceDebug(downloadTo, "Downloading " + downloadTo + " using "
-                    + downloadFrom + " (encoding : " + contentEncoding + ") ");
-
+            // Only an identity (uncompressed) 206 whose Content-Range lined up with the
+            // on-disk prefix is byte-resumable. pack200-gzip / gzip bodies are not.
             boolean packgz = "pack200-gzip".equals(contentEncoding)
                     || downloadFrom.getPath().endsWith(".pack.gz");
             boolean gzip = "gzip".equals(contentEncoding);
+            boolean rangeHonored = status == HttpURLConnection.HTTP_PARTIAL && effectiveResume > 0
+                    && !packgz && !gzip;
+            // On a 206 the Content-Length is only the slice; report the full size for progress.
+            if (rangeHonored) {
+                long total = parseContentRangeTotal(response.getHeader("Content-Range"));
+                if (total > 0) {
+                    resource.setSize(total);
+                }
+            }
+
+            logResourceDebug(downloadTo, "Downloading " + downloadTo + " using "
+                    + downloadFrom + " (encoding : " + contentEncoding
+                    + (rangeHonored ? ", range resume from " + effectiveResume : "") + ") ");
 
             // It's important to check packgz first. If a stream is both
             // pack200 and gz encoded, then the Content-Encoding could
@@ -671,7 +714,8 @@ public class ResourceDownloader implements Runnable {
             } else if (gzip) {
                 downloadGZipFile(response, downloadFrom, downloadTo);
             } else {
-                downloadFile(response, downloadTo, false, null);
+                downloadFile(response, downloadTo, false, null, rangeHonored,
+                        rangeHonored ? effectiveResume : 0L);
             }
             settleSlotGood(false);
             CachedDaemonThreadPoolProvider.noteJarDownloadSucceeded();
@@ -687,9 +731,86 @@ public class ResourceDownloader implements Runnable {
         }
     }
 
+    /**
+     * Whether a response to a ranged GET must fall back to a full GET: a 416, or a 206
+     * whose Content-Range start does not equal the requested offset (the on-disk prefix
+     * would not line up with the served suffix). A 200 means the server ignored Range
+     * and is sending the full representation, which is handled by the normal truncate path.
+     */
+    private static boolean isRangeRejection(net.sourceforge.jnlp.security.HttpResponse response, int status, long rangeFrom) {
+        if (status == 416 /* Range Not Satisfiable */) {
+            return true;
+        }
+        if (status == HttpURLConnection.HTTP_PARTIAL) {
+            long[] cr = parseContentRange(response.getHeader("Content-Range"));
+            return cr == null || cr[0] != rangeFrom;
+        }
+        return false;
+    }
+
+    /**
+     * Determine whether an interrupted download can be resumed with HTTP Range: the
+     * on-disk cache file is a non-empty prefix shorter than the known remote length.
+     * Returns the byte offset to request ({@code 0} means "full GET") plus the cached
+     * Last-Modified for an {@code If-Range} conditional so a changed resource is served
+     * in full rather than appended.
+     */
+    private ResumeTarget computeResumeTarget() {
+        URL loc = resource.getLocation();
+        if (!isRangeResumeEnabled()) {
+            return ResumeTarget.NONE;
+        }
+        String protocol = loc.getProtocol();
+        if (!"http".equalsIgnoreCase(protocol) && !"https".equalsIgnoreCase(protocol)) {
+            return ResumeTarget.NONE;
+        }
+        CacheEntry probe = new CacheEntry(loc, resource.getDownloadVersion());
+        File partial = probe.getCacheFile();
+        if (partial == null || !partial.isFile()) {
+            return ResumeTarget.NONE;
+        }
+        long len = partial.length();
+        long remote = probe.getRemoteContentLength();
+        if (len <= 0 || (remote > 0 && len >= remote)) {
+            return ResumeTarget.NONE;
+        }
+        // A jar partial must still carry ZIP magic; never resume an error body or raw pack bytes.
+        if (CacheUtil.isJarResourceUrl(loc) && !CacheUtil.isValidJarFile(partial)) {
+            return ResumeTarget.NONE;
+        }
+        return new ResumeTarget(len, probe.getLastModified());
+    }
+
+    private static final class ResumeTarget {
+        static final ResumeTarget NONE = new ResumeTarget(0L, 0L);
+        final long offset;
+        final long ifRangeLastModified;
+
+        ResumeTarget(long offset, long ifRangeLastModified) {
+            this.offset = offset;
+            this.ifRangeLastModified = ifRangeLastModified;
+        }
+    }
+
     private net.sourceforge.jnlp.security.HttpResponse getDownloadConnection(URL location) throws IOException {
+        return getDownloadConnection(location, 0L, 0L);
+    }
+
+    private net.sourceforge.jnlp.security.HttpResponse getDownloadConnection(URL location, long rangeFrom, long ifRangeLastModified)
+            throws IOException {
         java.util.Map<String, String> headers = new java.util.HashMap<>();
         headers.put("Accept-Encoding", getAcceptEncoding());
+        // Resume an interrupted download by asking for the missing suffix (RFC 7233).
+        // If-Range makes the server return the full 200 representation when the resource
+        // has changed, so a stale prefix is never appended to.
+        String rangeHeader = buildRangeHeader(rangeFrom);
+        if (rangeHeader != null) {
+            headers.put("Range", rangeHeader);
+            String ifRange = formatIfRangeDate(ifRangeLastModified);
+            if (ifRange != null) {
+                headers.put("If-Range", ifRange);
+            }
+        }
         net.sourceforge.jnlp.cache.download.ConnectionTiming timing = new net.sourceforge.jnlp.cache.download.ConnectionTiming();
         net.sourceforge.jnlp.security.HttpResponse response =
                 net.sourceforge.jnlp.security.HttpClientProvider.getDefault().open(location, "GET", headers, timing);
@@ -804,7 +925,7 @@ public class ResourceDownloader implements Runnable {
         if (downloadFrom.equals(downloadTo)) {
             downloadFrom = new URL(downloadFrom + ".pack.gz");
         }
-        downloadFile(response, downloadFrom, true, null);
+        downloadFile(response, downloadFrom, true, null, false, 0L);
 
         uncompressPackGz(downloadFrom, downloadTo, resource.getDownloadVersion());
         CacheEntry entry = new CacheEntry(downloadFrom, resource.getDownloadVersion());
@@ -817,14 +938,14 @@ public class ResourceDownloader implements Runnable {
             downloadFrom = new URL(downloadFrom + ".pack.gz");
         }
         CacheEntry entry = new CacheEntry(downloadTo, resource.getDownloadVersion(), true);
-        downloadFile(response, downloadFrom, true, entry);
+        downloadFile(response, downloadFrom, true, entry, false, 0L);
         storeEntryFields(entry, entry.getCacheFile().length(), response.getLastModified());
     }
 
     private void downloadGZipFile(net.sourceforge.jnlp.security.HttpResponse response, URL downloadFrom, URL downloadTo) throws IOException {
         if (downloadFrom.equals(downloadTo))
             downloadFrom = new URL(downloadFrom + ".gz");
-        downloadFile(response, downloadFrom, false, null);
+        downloadFile(response, downloadFrom, false, null, false, 0L);
 
         uncompressGzip(downloadFrom, downloadTo, resource.getDownloadVersion());
         CacheEntry entry = new CacheEntry(downloadTo, resource.getDownloadVersion());
@@ -832,7 +953,8 @@ public class ResourceDownloader implements Runnable {
         markForDelete(downloadFrom);
     }
 
-    private void downloadFile(net.sourceforge.jnlp.security.HttpResponse response, URL downloadLocation, boolean packGZ, CacheEntry entry) throws IOException {
+    private void downloadFile(net.sourceforge.jnlp.security.HttpResponse response, URL downloadLocation, boolean packGZ, CacheEntry entry,
+            boolean append, long resumeOffset) throws IOException {
         CacheEntry downloadEntry = entry != null ? entry
                 : new CacheEntry(downloadLocation, resource.getDownloadVersion());
         // Always persist to the cache entry location (usually resource.getLocation()).
@@ -852,7 +974,7 @@ public class ResourceDownloader implements Runnable {
             final File pinnedJar = downloadEntry.getCacheFile();
             try {
                 writtenFile = writeDownloadStream(cacheLocation, response.getBody(), packGZ,
-                        response.getContentLength(), pinnedJar);
+                        response.getContentLength(), pinnedJar, append, resumeOffset);
                 wrote = true;
             } catch (IOException ex) {
                 if (isFavIconUrl(downloadLocation)) {
@@ -870,7 +992,7 @@ public class ResourceDownloader implements Runnable {
                     OutputController.getLogger().log(head);
                     OutputController.getLogger().log("Body is: " + body.length + " bytes long");
                     writtenFile = writeDownloadStream(cacheLocation, new ByteArrayInputStream(body), packGZ,
-                            body != null ? body.length : -1L, pinnedJar);
+                            body != null ? body.length : -1L, pinnedJar, false, 0L);
                     wrote = true;
                 } else {
                     logDownloadFailure(downloadLocation, ex);
@@ -940,11 +1062,16 @@ public class ResourceDownloader implements Runnable {
 
     private File writeDownloadStream(URL cacheLocation, InputStream raw, boolean packGZ, long contentLength,
             File pinnedJar) throws IOException {
+        return writeDownloadStream(cacheLocation, raw, packGZ, contentLength, pinnedJar, false, 0L);
+    }
+
+    private File writeDownloadStream(URL cacheLocation, InputStream raw, boolean packGZ, long contentLength,
+            File pinnedJar, boolean append, long resumeOffset) throws IOException {
         // Validate the exact file we wrote — a second getCacheFile() can resolve a different
         // LRU slot and falsely reject a good pack200 unpack (or leave poison on disk).
         File written = packGZ
                 ? drainThenUnpackPackGz(cacheLocation, raw, pinnedJar)
-                : writeDownloadToFile(cacheLocation, new BufferedInputStream(raw), pinnedJar);
+                : writeDownloadToFile(cacheLocation, new BufferedInputStream(raw), pinnedJar, append, resumeOffset);
         // compressionRatio metric: on-disk decompressed size vs wire bytes
         net.sourceforge.jnlp.cache.download.JarSlot slot = resource.getJarSlot();
         if (slot != null && written != null) {
@@ -1100,11 +1227,82 @@ public class ResourceDownloader implements Runnable {
         return 0L;
     }
 
+    /**
+     * Build an HTTP {@code Range} request-header value for an open-ended suffix
+     * resume ({@code bytes=<offset>-}), or {@code null} when no resume is requested.
+     * Package-visible for unit tests.
+     */
+    static String buildRangeHeader(long offset) {
+        if (offset <= 0) {
+            return null;
+        }
+        return "bytes=" + offset + "-";
+    }
+
+    /**
+     * Format an epoch-millisecond Last-Modified as an RFC 7232 {@code If-Range}
+     * HTTP-date (RFC 1123, GMT), or {@code null} when unknown. Used so a server
+     * serves a full 200 (not a 206 suffix) when the representation has changed.
+     */
+    static String formatIfRangeDate(long lastModifiedMillis) {
+        if (lastModifiedMillis <= 0) {
+            return null;
+        }
+        return Instant.ofEpochMilli(lastModifiedMillis)
+                .atZone(ZoneOffset.UTC)
+                .format(DateTimeFormatter.RFC_1123_DATE_TIME);
+    }
+
+    /**
+     * Parse a {@code Content-Range} header ({@code bytes &lt;start&gt;-&lt;end&gt;/&lt;total&gt;},
+     * with a space after the unit as emitted by RFC 7233 servers) into
+     * {@code [start, end, total]}. {@code total} is {@code -1} when the server sent
+     * {@code *} (e.g. on a 416). Returns {@code null} when absent or malformed.
+     * Package-visible for unit tests.
+     */
+    static long[] parseContentRange(String contentRange) {
+        if (contentRange == null) {
+            return null;
+        }
+        String s = contentRange.trim();
+        if (!s.regionMatches(true, 0, "bytes", 0, 5)) {
+            return null;
+        }
+        s = s.substring(5).trim();
+        int slash = s.lastIndexOf('/');
+        if (slash < 0) {
+            return null;
+        }
+        String rangePart = s.substring(0, slash).trim();
+        String totalPart = s.substring(slash + 1).trim();
+        int dash = rangePart.indexOf('-');
+        if (dash < 0) {
+            return null;
+        }
+        try {
+            long start = Long.parseLong(rangePart.substring(0, dash).trim());
+            long end = Long.parseLong(rangePart.substring(dash + 1).trim());
+            long total = "*".equals(totalPart) ? -1L : Long.parseLong(totalPart);
+            return new long[]{start, end, total};
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private static long parseContentRangeTotal(String contentRange) {
+        long[] cr = parseContentRange(contentRange);
+        return cr != null ? cr[2] : -1L;
+    }
+
     private File writeDownloadToFile(URL downloadLocation, InputStream in) throws IOException {
         return writeDownloadToFile(downloadLocation, in, null);
     }
 
     private File writeDownloadToFile(URL downloadLocation, InputStream in, File pinnedJar) throws IOException {
+        return writeDownloadToFile(downloadLocation, in, pinnedJar, false, 0L);
+    }
+
+    private File writeDownloadToFile(URL downloadLocation, InputStream in, File pinnedJar, boolean append, long resumeOffset) throws IOException {
         File localFile = pinnedJar != null ? pinnedJar
                 : CacheUtil.getCacheFile(downloadLocation, resource.getDownloadVersion());
         File parent = localFile.getParentFile();
@@ -1113,7 +1311,9 @@ public class ResourceDownloader implements Runnable {
         }
         // Raw JAR/GET only. Pack200 sidecars use writeCountedStreamToFile with
         // expected=-1: resource.size is the unpacked jar, not the .pack.gz wire size.
-        writeCountedStreamToFile(localFile, in, resource, resource.getJarSlot(), resource.getSize());
+        // On a 206 append, seed written with resumeOffset so expected is the full size.
+        writeCountedStreamToFile(localFile, in, resource, resource.getJarSlot(),
+                resource.getSize(), append, resumeOffset);
         return localFile;
     }
 
@@ -1124,15 +1324,34 @@ public class ResourceDownloader implements Runnable {
 
     static void writeCountedStreamToFile(File dest, InputStream in, Resource resource,
             net.sourceforge.jnlp.cache.download.JarSlot slot) throws IOException {
-        writeCountedStreamToFile(dest, in, resource, slot, -1L);
+        writeCountedStreamToFile(dest, in, resource, slot, -1L, false, 0L);
     }
 
     static void writeCountedStreamToFile(File dest, InputStream in, Resource resource,
             net.sourceforge.jnlp.cache.download.JarSlot slot, long expected) throws IOException {
+        writeCountedStreamToFile(dest, in, resource, slot, expected, false, 0L);
+    }
+
+    /**
+     * Copy HTTP bytes to {@code dest}. When {@code append} is true (a resumed 206), the
+     * stream is appended to the existing partial file and the progress/metric counters
+     * are seeded with {@code resumeOffset} so TTFB/throughput and the reported
+     * transferred total reflect the whole resource, not just the suffix.
+     */
+    static void writeCountedStreamToFile(File dest, InputStream in, Resource resource,
+            net.sourceforge.jnlp.cache.download.JarSlot slot, long expected, boolean append, long resumeOffset) throws IOException {
         byte buf[] = new byte[COPY_BUFFER_SIZE_64KB];
         int rlen;
-        long written = 0L;
-        try (OutputStream out = new BufferedOutputStream(new FileOutputStream(dest))) {
+        long written = append && resumeOffset > 0 ? resumeOffset : 0L;
+        if (append && resumeOffset > 0) {
+            if (resource != null) {
+                resource.incrementTransferred(resumeOffset);
+            }
+            if (slot != null) {
+                slot.addTransferred(resumeOffset);
+            }
+        }
+        try (OutputStream out = new BufferedOutputStream(new FileOutputStream(dest, append))) {
             while (-1 != (rlen = in.read(buf))) {
                 written += rlen;
                 if (expected > 0 && written > expected) {

--- a/netx/net/sourceforge/jnlp/cache/ResourceDownloader.java
+++ b/netx/net/sourceforge/jnlp/cache/ResourceDownloader.java
@@ -763,6 +763,9 @@ public class ResourceDownloader implements Runnable {
                 resource.setLocalFile(reassembled);
                 storeEntryFields(entry, reassembled.length(), lastModified);
             } else {
+                // Not splitting this time: discard any parts left by an earlier abandoned split.
+                MultipartRangeDownloader.cleanupStaleParts(
+                        new CacheEntry(downloadTo, resource.getDownloadVersion()).getCacheFile());
                 downloadFile(response, downloadTo, false, null, rangeHonored,
                         rangeHonored ? effectiveResume : 0L);
             }

--- a/netx/net/sourceforge/jnlp/cache/ResourceDownloader.java
+++ b/netx/net/sourceforge/jnlp/cache/ResourceDownloader.java
@@ -63,6 +63,13 @@ public class ResourceDownloader implements Runnable {
         return PACK200_GZIP_ENCODING;
     }
     private static final Set<String> LOGGED_MISSING_FAVICONS = java.util.concurrent.ConcurrentHashMap.newKeySet();
+    /**
+     * Per-session memory of origins that answered a {@code Range} request with a full 200
+     * (i.e. ignored RFC 7233 Range). Once noted, the remaining downloads in the session from
+     * that origin use a plain GET — no resume suffix and no multipart probe. Scoped to the
+     * JVM, which is one launch; a fresh {@code javaws} probes again.
+     */
+    private static final Set<String> RANGE_UNSUPPORTED_HOSTS = java.util.concurrent.ConcurrentHashMap.newKeySet();
     private final Resource resource;
     /**
      * Pre-computed URL candidates (version-encoded, query-param, plain) to
@@ -213,6 +220,49 @@ public class ResourceDownloader implements Runnable {
         } catch (Exception e) {
             return 0L;
         }
+    }
+
+    /**
+     * Origin key ({@code scheme://host[:port]}) used for the per-session no-Range memory,
+     * so all downloads on the same origin share one flag.
+     */
+    static String rangeHostKey(URL url) {
+        if (url == null) {
+            return null;
+        }
+        String host = url.getHost();
+        if (host == null || host.isEmpty()) {
+            return null;
+        }
+        int port = url.getPort();
+        return url.getProtocol() + "://" + host + (port >= 0 ? ":" + port : "");
+    }
+
+    /**
+     * Whether this origin has already shown it ignores Range (answered a Range request with
+     * a full 200). When true the download skips resume and the multipart probe.
+     */
+    static boolean isRangeUnsupportedHost(URL url) {
+        String key = rangeHostKey(url);
+        return key != null && RANGE_UNSUPPORTED_HOSTS.contains(key);
+    }
+
+    /**
+     * Remember that the origin of {@code url} ignored Range. Called once per session when a
+     * Range request comes back as a full 200, so later downloads from the host stop probing.
+     */
+    static void noteRangeUnsupported(URL url) {
+        String key = rangeHostKey(url);
+        if (key == null || !RANGE_UNSUPPORTED_HOSTS.add(key)) {
+            return;
+        }
+        OutputController.getLogger().log(OutputController.Level.MESSAGE_DEBUG,
+                "Server " + key + " ignored Range (full 200) - using plain GET for this session");
+    }
+
+    /** Test seam - clears the per-session no-Range memory. */
+    static void resetRangeUnsupportedHosts() {
+        RANGE_UNSUPPORTED_HOSTS.clear();
     }
 
     /**
@@ -640,6 +690,8 @@ public class ResourceDownloader implements Runnable {
         final boolean multipartEligible = effectiveResume == 0
                 && slotSize > 0
                 && isRangeEnabled()
+                && !isRangeUnsupportedHost(rangeLoc)
+                && CacheUtil.isJarResourceUrl(rangeLoc)
                 && ("http".equalsIgnoreCase(rangeLoc.getProtocol())
                         || "https".equalsIgnoreCase(rangeLoc.getProtocol()))
                 && !rangeLoc.getPath().toLowerCase().endsWith(".pack.gz");
@@ -661,6 +713,13 @@ public class ResourceDownloader implements Runnable {
                     response = getDownloadConnection(candidate, rangeHeader, resume.ifRangeLastModified);
                     int status = response.getStatusCode();
                     long requestedStart = effectiveResume > 0 ? effectiveResume : 0L;
+                    if (rangeHeader != null && status == HttpURLConnection.HTTP_OK
+                            && CacheUtil.isJarResourceUrl(candidate)) {
+                        // The server ignored Range and sent the full 200 body: remember the origin
+                        // so the remaining downloads in this session stop sending Range (no more
+                        // probes / resume attempts from the same host).
+                        noteRangeUnsupported(candidate);
+                    }
                     if (rangeHeader != null && isRangeRejection(response, status, requestedStart)) {
                         // Server rejected the Range (416) or returned a 206 whose Content-Range
                         // does not line up with the requested offset. Applies to both a resume
@@ -814,6 +873,12 @@ public class ResourceDownloader implements Runnable {
         }
         String protocol = loc.getProtocol();
         if (!"http".equalsIgnoreCase(protocol) && !"https".equalsIgnoreCase(protocol)) {
+            return ResumeTarget.NONE;
+        }
+        if (isRangeUnsupportedHost(loc)) {
+            return ResumeTarget.NONE;
+        }
+        if (!CacheUtil.isJarResourceUrl(loc)) {
             return ResumeTarget.NONE;
         }
         CacheEntry probe = new CacheEntry(loc, resource.getDownloadVersion());

--- a/netx/net/sourceforge/jnlp/config/Defaults.java
+++ b/netx/net/sourceforge/jnlp/config/Defaults.java
@@ -616,9 +616,14 @@ public class Defaults {
                         String.valueOf(1)
                 },
                 {
-                        DeploymentConfiguration.KEY_HTTP_RANGE_RESUME,
+                        DeploymentConfiguration.KEY_HTTP_RANGE_ENABLED,
                         BasicValueValidators.getBooleanValidator(),
                         String.valueOf(true)
+                },
+                {
+                        DeploymentConfiguration.KEY_HTTP_RANGE_MAX_SLOT_BYTES,
+                        BasicValueValidators.getRangedIntegerValidator(0, Integer.MAX_VALUE),
+                        String.valueOf(50 * 1024 * 1024)
                 },
                 //**************
                 //* Native (rust) only - beggin

--- a/netx/net/sourceforge/jnlp/config/Defaults.java
+++ b/netx/net/sourceforge/jnlp/config/Defaults.java
@@ -615,6 +615,11 @@ public class Defaults {
                         BasicValueValidators.getRangedIntegerValidator(1, 200),
                         String.valueOf(1)
                 },
+                {
+                        DeploymentConfiguration.KEY_HTTP_RANGE_RESUME,
+                        BasicValueValidators.getBooleanValidator(),
+                        String.valueOf(true)
+                },
                 //**************
                 //* Native (rust) only - beggin
                 //**************

--- a/netx/net/sourceforge/jnlp/config/DeploymentConfiguration.java
+++ b/netx/net/sourceforge/jnlp/config/DeploymentConfiguration.java
@@ -432,6 +432,14 @@ public final class DeploymentConfiguration {
      */
     public static final String KEY_HTTP_PACK200_ADMISSION_LARGE_WIRE_MULTIPLIER =
             "deployment.http.pack200.admission.largeWireMultiplier";
+    /**
+     * Boolean. If true (default), resume interrupted downloads with an HTTP
+     * Range request (RFC 7233) when a partial cache file exists: send
+     * {@code Range: bytes=<cachedLen>-} (plus {@code If-Range} when the cached
+     * Last-Modified is known), append the 206 suffix, and fall back to a full
+     * GET on 200/416 so old servers keep working.
+     */
+    public static final String KEY_HTTP_RANGE_RESUME = "deployment.http.range.resume";
 
     public static final String TRANSFER_TITLE = "Legacy configuration and cache found. Those will be now transported to new locations";
     

--- a/netx/net/sourceforge/jnlp/config/DeploymentConfiguration.java
+++ b/netx/net/sourceforge/jnlp/config/DeploymentConfiguration.java
@@ -433,13 +433,23 @@ public final class DeploymentConfiguration {
     public static final String KEY_HTTP_PACK200_ADMISSION_LARGE_WIRE_MULTIPLIER =
             "deployment.http.pack200.admission.largeWireMultiplier";
     /**
-     * Boolean. If true (default), resume interrupted downloads with an HTTP
-     * Range request (RFC 7233) when a partial cache file exists: send
-     * {@code Range: bytes=<cachedLen>-} (plus {@code If-Range} when the cached
-     * Last-Modified is known), append the 206 suffix, and fall back to a full
-     * GET on 200/416 so old servers keep working.
+     * Boolean. If true (default), enable HTTP Range (RFC 7233) for downloads. Two behaviours:
+     * <ul>
+     *   <li>resume an interrupted download by requesting the missing suffix
+     *       ({@code Range: bytes=<cachedLen>-}, with {@code If-Range}) and appending the 206;</li>
+     *   <li>split a large fresh download into parallel chunks of at most
+     *       {@link #KEY_HTTP_RANGE_MAX_SLOT_BYTES} bytes each, then reassemble them.</li>
+     * </ul>
+     * Old / range-unaware servers fall back to today's full GET on a 200/416.
      */
-    public static final String KEY_HTTP_RANGE_RESUME = "deployment.http.range.resume";
+    public static final String KEY_HTTP_RANGE_ENABLED = "deployment.http.range.enabled";
+    /**
+     * Positive long. Maximum byte size of each parallel Range chunk for a fresh large download
+     * (e.g. a 200&nbsp;MB jar with a 50&nbsp;MB slot size splits into 4 parallel chunks).
+     * {@code 0} disables the multipart split (resume still works when range is enabled).
+     * Default {@code 52428800} (50&nbsp;MB).
+     */
+    public static final String KEY_HTTP_RANGE_MAX_SLOT_BYTES = "deployment.http.range.maxSlotBytes";
 
     public static final String TRANSFER_TITLE = "Legacy configuration and cache found. Those will be now transported to new locations";
     

--- a/tests/netx/unit/net/sourceforge/jnlp/cache/ResourceDownloaderTest.java
+++ b/tests/netx/unit/net/sourceforge/jnlp/cache/ResourceDownloaderTest.java
@@ -831,4 +831,39 @@ public class ResourceDownloaderTest extends NoStdOutErrTest {
                     prevSlot != null ? prevSlot : String.valueOf(50 * 1024 * 1024));
         }
     }
+
+    @Test
+    public void testMultipartDisabledByZeroSlotSize() throws Exception {
+        byte[] full = makeMinimalJarBytes("1.5");
+        File remote = new File(rangeServer.getDir(), "multipart-off.jar");
+        remote.deleteOnExit();
+        Files.write(remote.toPath(), full);
+
+        URL url = rangeServer.getUrl("multipart-off.jar");
+        rangeHeaderSeen.set(null);
+
+        // slot size 0 disables the multipart split: a fresh download must NOT send a Range probe.
+        String prevSlot = JNLPRuntime.getConfiguration().getProperty(
+                net.sourceforge.jnlp.config.DeploymentConfiguration.KEY_HTTP_RANGE_MAX_SLOT_BYTES);
+        JNLPRuntime.getConfiguration().setProperty(
+                net.sourceforge.jnlp.config.DeploymentConfiguration.KEY_HTTP_RANGE_MAX_SLOT_BYTES, "0");
+        try {
+            Resource resource = Resource.getResource(url, null, UpdatePolicy.FORCE);
+            ResourceDownloader downloader = new ResourceDownloader(resource, new Object());
+            resource.setDownloadOptions(new DownloadOptions(false, false));
+            downloader.run();
+
+            File downloaded = resource.getLocalFile();
+            Assert.assertNotNull(downloaded);
+            byte[] result = Files.readAllBytes(downloaded.toPath());
+            Assert.assertEquals(full.length, result.length);
+            Assert.assertArrayEquals(full, result);
+            Assert.assertNull("slot size 0 must keep today's plain GET (no Range probe)",
+                    rangeHeaderSeen.get());
+        } finally {
+            JNLPRuntime.getConfiguration().setProperty(
+                    net.sourceforge.jnlp.config.DeploymentConfiguration.KEY_HTTP_RANGE_MAX_SLOT_BYTES,
+                    prevSlot != null ? prevSlot : String.valueOf(50 * 1024 * 1024));
+        }
+    }
 }

--- a/tests/netx/unit/net/sourceforge/jnlp/cache/ResourceDownloaderTest.java
+++ b/tests/netx/unit/net/sourceforge/jnlp/cache/ResourceDownloaderTest.java
@@ -797,4 +797,38 @@ public class ResourceDownloaderTest extends NoStdOutErrTest {
                 full.length, result.length);
         Assert.assertArrayEquals(full, result);
     }
+
+    @Test
+    public void testMultipartRangeSplitsAndReassembles() throws Exception {
+        byte[] full = makeMinimalJarBytes("1.4");
+        File remote = new File(rangeServer.getDir(), "multipart.jar");
+        remote.deleteOnExit();
+        Files.write(remote.toPath(), full);
+
+        URL url = rangeServer.getUrl("multipart.jar");
+        rangeHeaderSeen.set(null);
+
+        // Tiny slot size forces many parallel Range chunks (ceil(len/16)) and exercises reassembly.
+        String prevSlot = JNLPRuntime.getConfiguration().getProperty(
+                net.sourceforge.jnlp.config.DeploymentConfiguration.KEY_HTTP_RANGE_MAX_SLOT_BYTES);
+        JNLPRuntime.getConfiguration().setProperty(
+                net.sourceforge.jnlp.config.DeploymentConfiguration.KEY_HTTP_RANGE_MAX_SLOT_BYTES, "16");
+        try {
+            Resource resource = Resource.getResource(url, null, UpdatePolicy.FORCE);
+            ResourceDownloader downloader = new ResourceDownloader(resource, new Object());
+            resource.setDownloadOptions(new DownloadOptions(false, false));
+            downloader.run();
+
+            File downloaded = resource.getLocalFile();
+            Assert.assertNotNull("multipart download must produce a cache file", downloaded);
+            byte[] result = Files.readAllBytes(downloaded.toPath());
+            Assert.assertEquals("reassembled file must equal the full jar length",
+                    full.length, result.length);
+            Assert.assertArrayEquals("parallel chunks must reassemble into the original jar", full, result);
+        } finally {
+            JNLPRuntime.getConfiguration().setProperty(
+                    net.sourceforge.jnlp.config.DeploymentConfiguration.KEY_HTTP_RANGE_MAX_SLOT_BYTES,
+                    prevSlot != null ? prevSlot : String.valueOf(50 * 1024 * 1024));
+        }
+    }
 }

--- a/tests/netx/unit/net/sourceforge/jnlp/cache/ResourceDownloaderTest.java
+++ b/tests/netx/unit/net/sourceforge/jnlp/cache/ResourceDownloaderTest.java
@@ -1000,6 +1000,59 @@ public class ResourceDownloaderTest extends NoStdOutErrTest {
         }
     }
 
+    @Test
+    public void testRangeUnsupportedHostMemoryIsPerOriginAndResettable() throws Exception {
+        URL a = rangeServer.getUrl("flag-a.jar");
+        URL b = testServer.getUrl("flag-b.jar");
+        Assert.assertFalse("a fresh origin must not be flagged",
+                ResourceDownloader.isRangeUnsupportedHost(a));
+        Assert.assertFalse("a fresh unrelated origin must not be flagged",
+                ResourceDownloader.isRangeUnsupportedHost(b));
+
+        ResourceDownloader.noteRangeUnsupported(a);
+        Assert.assertTrue("noted origin must be remembered for the session",
+                ResourceDownloader.isRangeUnsupportedHost(a));
+        Assert.assertFalse("an unrelated origin must not be flagged",
+                ResourceDownloader.isRangeUnsupportedHost(b));
+
+        ResourceDownloader.resetRangeUnsupportedHosts();
+        Assert.assertFalse("reset must clear the session memory",
+                ResourceDownloader.isRangeUnsupportedHost(a));
+    }
+
+    @Test
+    public void testNotedUnsupportedHostSkipsRangeResume() throws Exception {
+        byte[] full = makeMinimalJarBytes("1.7");
+        File remote = new File(rangeServer.getDir(), "noted-resume.jar");
+        remote.deleteOnExit();
+        Files.write(remote.toPath(), full);
+
+        URL url = rangeServer.getUrl("noted-resume.jar");
+        int cut = Math.max(4, full.length / 2);
+        seedPartialCache(url, full, cut);
+
+        // The server would honour Range, but this session already saw the host ignore it
+        // (a 200 in answer to a Range). The client must not attempt a resume.
+        ResourceDownloader.noteRangeUnsupported(url);
+        rangeHeaderSeen.set(null);
+        try {
+            Resource resource = Resource.getResource(url, null, UpdatePolicy.FORCE);
+            resource.setDownloadOptions(new DownloadOptions(false, false));
+            new ResourceDownloader(resource, new Object()).run();
+
+            File downloaded = resource.getLocalFile();
+            Assert.assertNotNull(downloaded);
+            byte[] result = Files.readAllBytes(downloaded.toPath());
+            Assert.assertEquals("noted host: full GET must restore the full length",
+                    full.length, result.length);
+            Assert.assertArrayEquals(full, result);
+            Assert.assertNull("noted host must not send a Range resume request",
+                    rangeHeaderSeen.get());
+        } finally {
+            ResourceDownloader.resetRangeUnsupportedHosts();
+        }
+    }
+
     private static Thread runDownloaderAsync(final Resource resource, final Throwable[] err, final int slot) {
         Thread t = new Thread(() -> {
             try {

--- a/tests/netx/unit/net/sourceforge/jnlp/cache/ResourceDownloaderTest.java
+++ b/tests/netx/unit/net/sourceforge/jnlp/cache/ResourceDownloaderTest.java
@@ -45,6 +45,7 @@ public class ResourceDownloaderTest extends NoStdOutErrTest {
     public static ServerLauncher downloadServer;
     public static ServerLauncher rangeServer;
     private static java.util.concurrent.atomic.AtomicReference<String> rangeHeaderSeen;
+    private static java.util.concurrent.atomic.AtomicInteger rangeRequestCount;
 
     private static final PrintStream[] backedUpStream = new PrintStream[4];
     private static ByteArrayOutputStream currentErrorStream;
@@ -320,10 +321,12 @@ public class ResourceDownloaderTest extends NoStdOutErrTest {
         PathsAndFiles.CACHE_DIR.setValue(System.getProperty("java.io.tmpdir") + File.separator + "tempcache");
 
         rangeHeaderSeen = new java.util.concurrent.atomic.AtomicReference<>(null);
+        rangeRequestCount = new java.util.concurrent.atomic.AtomicInteger(0);
         redirectErr();
         rangeServer = ServerAccess.getIndependentInstance(dir.getAbsolutePath(), ServerAccess.findFreePort());
         rangeServer.setSupportRangeRequests(true);
         rangeServer.setRangeHeaderSink(rangeHeaderSeen);
+        rangeServer.setRangeRequestCounter(rangeRequestCount);
         redirectErrBack();
     }
 
@@ -865,5 +868,169 @@ public class ResourceDownloaderTest extends NoStdOutErrTest {
                     net.sourceforge.jnlp.config.DeploymentConfiguration.KEY_HTTP_RANGE_MAX_SLOT_BYTES,
                     prevSlot != null ? prevSlot : String.valueOf(50 * 1024 * 1024));
         }
+    }
+
+    @Test
+    public void testMultipartResumeSkipsCompletedChunks() throws Exception {
+        byte[] full = makeMinimalJarBytes("1.6");
+        File remote = new File(rangeServer.getDir(), "multipart-resume.jar");
+        remote.deleteOnExit();
+        Files.write(remote.toPath(), full);
+
+        URL url = rangeServer.getUrl("multipart-resume.jar");
+        int slot = 16;
+        int n = (full.length + slot - 1) / slot;
+
+        // Pre-seed the deterministic multipart parts dir with chunk 0 and chunk 2 already
+        // complete, simulating a prior interrupted split. A resumed transfer must skip those.
+        File dest = new CacheEntry(url, null).getCacheFile();
+        File tmpDir = new File(dest.getParentFile(), dest.getName() + ".multipart");
+        Files.createDirectories(tmpDir.toPath());
+        writePart(tmpDir, 0, full, slot);
+        writePart(tmpDir, 2, full, slot);
+
+        rangeRequestCount.set(0);
+        String prevSlot = JNLPRuntime.getConfiguration().getProperty(
+                net.sourceforge.jnlp.config.DeploymentConfiguration.KEY_HTTP_RANGE_MAX_SLOT_BYTES);
+        JNLPRuntime.getConfiguration().setProperty(
+                net.sourceforge.jnlp.config.DeploymentConfiguration.KEY_HTTP_RANGE_MAX_SLOT_BYTES, String.valueOf(slot));
+        try {
+            Resource resource = Resource.getResource(url, null, UpdatePolicy.FORCE);
+            ResourceDownloader downloader = new ResourceDownloader(resource, new Object());
+            resource.setDownloadOptions(new DownloadOptions(false, false));
+            downloader.run();
+
+            File downloaded = resource.getLocalFile();
+            Assert.assertNotNull(downloaded);
+            byte[] result = Files.readAllBytes(downloaded.toPath());
+            Assert.assertEquals("reassembled file must equal the full jar length",
+                    full.length, result.length);
+            Assert.assertArrayEquals(full, result);
+            // Full split = n Range requests (probe + n-1 chunks). Pre-seeding chunk 2 saves one,
+            // proving the resumed transfer skipped an already-complete chunk.
+            Assert.assertEquals("resumed transfer must skip pre-seeded chunks",
+                    (long) n - 1, (long) rangeRequestCount.get());
+            Assert.assertFalse("completed reassembly must clean up its parts dir",
+                    tmpDir.isDirectory());
+        } finally {
+            JNLPRuntime.getConfiguration().setProperty(
+                    net.sourceforge.jnlp.config.DeploymentConfiguration.KEY_HTTP_RANGE_MAX_SLOT_BYTES,
+                    prevSlot != null ? prevSlot : String.valueOf(50 * 1024 * 1024));
+            deleteRecursively(tmpDir);
+        }
+    }
+
+    @Test
+    public void testConcurrentMultipartDownloadsReassembleCorrectly() throws Exception {
+        byte[] fullA = makeMinimalJarBytes("2.1");
+        byte[] fullB = makeMinimalJarBytes("2.2");
+        File remoteA = new File(rangeServer.getDir(), "mp-a.jar");
+        File remoteB = new File(rangeServer.getDir(), "mp-b.jar");
+        remoteA.deleteOnExit();
+        remoteB.deleteOnExit();
+        Files.write(remoteA.toPath(), fullA);
+        Files.write(remoteB.toPath(), fullB);
+
+        Resource ra = Resource.getResource(rangeServer.getUrl("mp-a.jar"), null, UpdatePolicy.FORCE);
+        Resource rb = Resource.getResource(rangeServer.getUrl("mp-b.jar"), null, UpdatePolicy.FORCE);
+
+        String prevSlot = JNLPRuntime.getConfiguration().getProperty(
+                net.sourceforge.jnlp.config.DeploymentConfiguration.KEY_HTTP_RANGE_MAX_SLOT_BYTES);
+        JNLPRuntime.getConfiguration().setProperty(
+                net.sourceforge.jnlp.config.DeploymentConfiguration.KEY_HTTP_RANGE_MAX_SLOT_BYTES, "16");
+        try {
+            // Two resources splitting concurrently share the global chunk pool; both must finish whole.
+            final Throwable[] err = new Throwable[2];
+            Thread t1 = runDownloaderAsync(ra, err, 0);
+            Thread t2 = runDownloaderAsync(rb, err, 1);
+            t1.join();
+            t2.join();
+
+            if (err[0] != null) {
+                throw new AssertionError("mp-a failed", err[0]);
+            }
+            if (err[1] != null) {
+                throw new AssertionError("mp-b failed", err[1]);
+            }
+            Assert.assertArrayEquals("concurrent split A must reassemble the original jar",
+                    fullA, Files.readAllBytes(ra.getLocalFile().toPath()));
+            Assert.assertArrayEquals("concurrent split B must reassemble the original jar",
+                    fullB, Files.readAllBytes(rb.getLocalFile().toPath()));
+        } finally {
+            JNLPRuntime.getConfiguration().setProperty(
+                    net.sourceforge.jnlp.config.DeploymentConfiguration.KEY_HTTP_RANGE_MAX_SLOT_BYTES,
+                    prevSlot != null ? prevSlot : String.valueOf(50 * 1024 * 1024));
+        }
+    }
+
+    @Test
+    public void testStaleMultipartDirCleanedOnSingleGet() throws Exception {
+        byte[] full = makeMinimalJarBytes("2.3");
+        File remote = new File(rangeServer.getDir(), "mp-stale.jar");
+        remote.deleteOnExit();
+        Files.write(remote.toPath(), full);
+        URL url = rangeServer.getUrl("mp-stale.jar");
+
+        // Pre-create a stale .multipart dir as if a previous split had been abandoned.
+        File dest = new CacheEntry(url, null).getCacheFile();
+        File tmpDir = new File(dest.getParentFile(), dest.getName() + ".multipart");
+        Files.createDirectories(tmpDir.toPath());
+        Files.write(new File(tmpDir, "part-0").toPath(), new byte[] { 0 });
+        Assert.assertTrue(tmpDir.isDirectory());
+
+        String prevSlot = JNLPRuntime.getConfiguration().getProperty(
+                net.sourceforge.jnlp.config.DeploymentConfiguration.KEY_HTTP_RANGE_MAX_SLOT_BYTES);
+        JNLPRuntime.getConfiguration().setProperty(
+                net.sourceforge.jnlp.config.DeploymentConfiguration.KEY_HTTP_RANGE_MAX_SLOT_BYTES, "0");
+        try {
+            Resource resource = Resource.getResource(url, null, UpdatePolicy.FORCE);
+            resource.setDownloadOptions(new DownloadOptions(false, false));
+            new ResourceDownloader(resource, new Object()).run();
+
+            File downloaded = resource.getLocalFile();
+            Assert.assertNotNull(downloaded);
+            Assert.assertArrayEquals(full, Files.readAllBytes(downloaded.toPath()));
+            Assert.assertFalse("non-multipart download must clean up a stale parts dir",
+                    tmpDir.isDirectory());
+        } finally {
+            JNLPRuntime.getConfiguration().setProperty(
+                    net.sourceforge.jnlp.config.DeploymentConfiguration.KEY_HTTP_RANGE_MAX_SLOT_BYTES,
+                    prevSlot != null ? prevSlot : String.valueOf(50 * 1024 * 1024));
+            deleteRecursively(tmpDir);
+        }
+    }
+
+    private static Thread runDownloaderAsync(final Resource resource, final Throwable[] err, final int slot) {
+        Thread t = new Thread(() -> {
+            try {
+                resource.setDownloadOptions(new DownloadOptions(false, false));
+                new ResourceDownloader(resource, new Object()).run();
+            } catch (Throwable th) {
+                err[slot] = th;
+            }
+        }, "itw-test-mp-" + slot);
+        t.setDaemon(true);
+        t.start();
+        return t;
+    }
+
+    private static void writePart(File tmpDir, int idx, byte[] full, int slot) throws IOException {
+        long start = (long) idx * slot;
+        long end = Math.min(start + slot - 1, full.length - 1);
+        int len = (int) (end - start + 1);
+        Files.write(new File(tmpDir, "part-" + idx).toPath(), java.util.Arrays.copyOfRange(full, (int) start, (int) start + len));
+    }
+
+    private static void deleteRecursively(File f) {
+        if (f == null || !f.exists()) {
+            return;
+        }
+        File[] kids = f.listFiles();
+        if (kids != null) {
+            for (File k : kids) {
+                deleteRecursively(k);
+            }
+        }
+        f.delete();
     }
 }

--- a/tests/netx/unit/net/sourceforge/jnlp/cache/ResourceDownloaderTest.java
+++ b/tests/netx/unit/net/sourceforge/jnlp/cache/ResourceDownloaderTest.java
@@ -43,6 +43,8 @@ public class ResourceDownloaderTest extends NoStdOutErrTest {
     public static ServerLauncher testServer;
     public static ServerLauncher testServerWithBrokenHead;
     public static ServerLauncher downloadServer;
+    public static ServerLauncher rangeServer;
+    private static java.util.concurrent.atomic.AtomicReference<String> rangeHeaderSeen;
 
     private static final PrintStream[] backedUpStream = new PrintStream[4];
     private static ByteArrayOutputStream currentErrorStream;
@@ -316,11 +318,19 @@ public class ResourceDownloaderTest extends NoStdOutErrTest {
 
         cacheDir = PathsAndFiles.CACHE_DIR.getFullPath();
         PathsAndFiles.CACHE_DIR.setValue(System.getProperty("java.io.tmpdir") + File.separator + "tempcache");
+
+        rangeHeaderSeen = new java.util.concurrent.atomic.AtomicReference<>(null);
+        redirectErr();
+        rangeServer = ServerAccess.getIndependentInstance(dir.getAbsolutePath(), ServerAccess.findFreePort());
+        rangeServer.setSupportRangeRequests(true);
+        rangeServer.setRangeHeaderSink(rangeHeaderSeen);
+        redirectErrBack();
     }
 
     @AfterClass
     public static void teardownCache() {
         downloadServer.stop();
+        rangeServer.stop();
 
         CacheUtil.clearCache();
         PathsAndFiles.CACHE_DIR.setValue(cacheDir);
@@ -674,5 +684,117 @@ public class ResourceDownloaderTest extends NoStdOutErrTest {
             return Integer.parseInt(elements[1]);
         }
         return discard;
+    }
+
+    @Test
+    public void rangeHeaderBuiltFromPartialCacheLength() {
+        Assert.assertNull("no resume when offset <= 0", ResourceDownloader.buildRangeHeader(0L));
+        Assert.assertNull(ResourceDownloader.buildRangeHeader(-1L));
+        Assert.assertEquals("bytes=512-", ResourceDownloader.buildRangeHeader(512L));
+        Assert.assertEquals("bytes=1-", ResourceDownloader.buildRangeHeader(1L));
+    }
+
+    @Test
+    public void parseContentRangeReadsStartEndTotal() {
+        long[] r = ResourceDownloader.parseContentRange("bytes 512-3851/3852");
+        Assert.assertNotNull(r);
+        Assert.assertEquals(512L, r[0]);
+        Assert.assertEquals(3851L, r[1]);
+        Assert.assertEquals(3852L, r[2]);
+        // unit is case-insensitive; response Content-Range always carries start-end/total
+        long[] open = ResourceDownloader.parseContentRange("BYTES 90-99/100");
+        Assert.assertNotNull(open);
+        Assert.assertEquals(90L, open[0]);
+        Assert.assertEquals(99L, open[1]);
+        Assert.assertEquals(100L, open[2]);
+        Assert.assertNull(ResourceDownloader.parseContentRange(null));
+        Assert.assertNull(ResourceDownloader.parseContentRange("bytes */100"));
+        Assert.assertNull(ResourceDownloader.parseContentRange("items 0-9/10"));
+    }
+
+    @Test
+    public void formatIfRangeDateIsRfc1123Gmt() {
+        Assert.assertNull(ResourceDownloader.formatIfRangeDate(0L));
+        Assert.assertNull(ResourceDownloader.formatIfRangeDate(-1L));
+        String d = ResourceDownloader.formatIfRangeDate(1_600_000_000_000L);
+        Assert.assertTrue("expected RFC 1123 GMT date, got " + d, d.endsWith(" GMT") && d.contains(","));
+    }
+
+    private static byte[] makeMinimalJarBytes(String manifestVersion) throws IOException {
+        File tmp = File.createTempFile("range-jar", ".jar");
+        tmp.deleteOnExit();
+        Manifest manifest = new Manifest();
+        manifest.getMainAttributes().put(Attributes.Name.MANIFEST_VERSION, manifestVersion);
+        try (JarOutputStream jos = new JarOutputStream(new FileOutputStream(tmp), manifest)) {
+            java.util.jar.JarEntry entry = new java.util.jar.JarEntry("payload.txt");
+            jos.putNextEntry(entry);
+            jos.write("hello-range-resume".getBytes());
+            jos.closeEntry();
+        }
+        return Files.readAllBytes(tmp.toPath());
+    }
+
+    private static void seedPartialCache(URL url, byte[] full, int cut) throws IOException {
+        CacheEntry seed = new CacheEntry(url, null);
+        File cacheFile = seed.getCacheFile();
+        Files.createDirectories(cacheFile.toPath().getParent());
+        Files.write(cacheFile.toPath(), java.util.Arrays.copyOf(full, cut));
+        seed.setRemoteContentLength(full.length);
+        seed.setLastModified(0L);
+        seed.lock();
+        seed.store();
+        seed.unlock();
+    }
+
+    @Test
+    public void testResumeAppendsSuffixOnHttp206() throws Exception {
+        byte[] full = makeMinimalJarBytes("1.2");
+        File remote = new File(rangeServer.getDir(), "resume.jar");
+        remote.deleteOnExit();
+        Files.write(remote.toPath(), full);
+
+        URL url = rangeServer.getUrl("resume.jar");
+        rangeHeaderSeen.set(null);
+        int cut = Math.max(4, full.length / 2);
+        seedPartialCache(url, full, cut);
+
+        Resource resource = Resource.getResource(url, null, UpdatePolicy.FORCE);
+        ResourceDownloader downloader = new ResourceDownloader(resource, new Object());
+        resource.setDownloadOptions(new DownloadOptions(false, false));
+        downloader.run();
+
+        File downloaded = resource.getLocalFile();
+        Assert.assertNotNull("resumed download must produce a cache file", downloaded);
+        byte[] result = Files.readAllBytes(downloaded.toPath());
+        Assert.assertEquals("resumed file must be the full resource length", full.length, result.length);
+        Assert.assertArrayEquals("appended suffix must reconstruct the original jar", full, result);
+        String rangeSent = rangeHeaderSeen.get();
+        Assert.assertNotNull("client must send a Range header to resume", rangeSent);
+        Assert.assertEquals("client must request the suffix from the cached length",
+                "bytes=" + cut + "-", rangeSent);
+    }
+
+    @Test
+    public void testServerWithoutRangeFullDownloadsNoAppend() throws Exception {
+        byte[] full = makeMinimalJarBytes("1.3");
+        File remote = new File(downloadServer.getDir(), "no-range.jar");
+        remote.deleteOnExit();
+        Files.write(remote.toPath(), full);
+
+        URL url = downloadServer.getUrl("no-range.jar");
+        int cut = Math.max(4, full.length / 2);
+        seedPartialCache(url, full, cut);
+
+        Resource resource = Resource.getResource(url, null, UpdatePolicy.FORCE);
+        ResourceDownloader downloader = new ResourceDownloader(resource, new Object());
+        resource.setDownloadOptions(new DownloadOptions(false, false));
+        downloader.run();
+
+        File downloaded = resource.getLocalFile();
+        Assert.assertNotNull(downloaded);
+        byte[] result = Files.readAllBytes(downloaded.toPath());
+        Assert.assertEquals("server ignored Range: client must replace, not append (no length doubling)",
+                full.length, result.length);
+        Assert.assertArrayEquals(full, result);
     }
 }

--- a/tests/test-extensions/net/sourceforge/jnlp/ServerLauncher.java
+++ b/tests/test-extensions/net/sourceforge/jnlp/ServerLauncher.java
@@ -69,6 +69,8 @@ public class ServerLauncher implements Runnable, Authentication511Requester {
     private ServerSocket serverSocket;
     private boolean supportingHeadRequest = true;
     private ServerNaming serverNaming = ServerNaming.LOCALHOST;
+    private boolean supportRangeRequests = false;
+    private java.util.concurrent.atomic.AtomicReference<String> rangeHeaderSink = null;
 
     public void setSupportingHeadRequest(boolean supportsHead) {
         this.supportingHeadRequest = supportsHead;
@@ -76,6 +78,20 @@ public class ServerLauncher implements Runnable, Authentication511Requester {
 
     public boolean isSupportingHeadRequest() {
         return supportingHeadRequest;
+    }
+
+    /** Enable RFC 7233 Range serving on every per-connection handler. */
+    public void setSupportRangeRequests(boolean supportRangeRequests) {
+        this.supportRangeRequests = supportRangeRequests;
+    }
+
+    public boolean isSupportingRangeRequests() {
+        return supportRangeRequests;
+    }
+
+    /** Shared holder recording the last Range header seen by any handler. */
+    public void setRangeHeaderSink(java.util.concurrent.atomic.AtomicReference<String> rangeHeaderSink) {
+        this.rangeHeaderSink = rangeHeaderSink;
     }
 
     public void setServerNaming(ServerNaming naming) {
@@ -170,6 +186,8 @@ public class ServerLauncher implements Runnable, Authentication511Requester {
                 server.setRedirectCode(redirectCode);
                 server.setRequestsCounter(requestsCounter);
                 server.setSupportingHeadRequest(isSupportingHeadRequest());
+                server.setSupportRangeRequests(supportRangeRequests);
+                server.setRangeHeaderSink(rangeHeaderSink);
                 if (isNeedsAuthentication511()) {
                     server.setAuthenticator(this);
                 }

--- a/tests/test-extensions/net/sourceforge/jnlp/ServerLauncher.java
+++ b/tests/test-extensions/net/sourceforge/jnlp/ServerLauncher.java
@@ -71,6 +71,7 @@ public class ServerLauncher implements Runnable, Authentication511Requester {
     private ServerNaming serverNaming = ServerNaming.LOCALHOST;
     private boolean supportRangeRequests = false;
     private java.util.concurrent.atomic.AtomicReference<String> rangeHeaderSink = null;
+    private java.util.concurrent.atomic.AtomicInteger rangeRequestCounter = null;
 
     public void setSupportingHeadRequest(boolean supportsHead) {
         this.supportingHeadRequest = supportsHead;
@@ -92,6 +93,11 @@ public class ServerLauncher implements Runnable, Authentication511Requester {
     /** Shared holder recording the last Range header seen by any handler. */
     public void setRangeHeaderSink(java.util.concurrent.atomic.AtomicReference<String> rangeHeaderSink) {
         this.rangeHeaderSink = rangeHeaderSink;
+    }
+
+    /** Shared counter of Range-header requests, propagated to every per-connection handler. */
+    public void setRangeRequestCounter(java.util.concurrent.atomic.AtomicInteger rangeRequestCounter) {
+        this.rangeRequestCounter = rangeRequestCounter;
     }
 
     public void setServerNaming(ServerNaming naming) {
@@ -188,6 +194,7 @@ public class ServerLauncher implements Runnable, Authentication511Requester {
                 server.setSupportingHeadRequest(isSupportingHeadRequest());
                 server.setSupportRangeRequests(supportRangeRequests);
                 server.setRangeHeaderSink(rangeHeaderSink);
+                server.setRangeRequestCounter(rangeRequestCounter);
                 if (isNeedsAuthentication511()) {
                     server.setAuthenticator(this);
                 }

--- a/tests/test-extensions/net/sourceforge/jnlp/TinyHttpdImpl.java
+++ b/tests/test-extensions/net/sourceforge/jnlp/TinyHttpdImpl.java
@@ -76,6 +76,7 @@ public class TinyHttpdImpl extends Thread {
     private boolean supportLastModified = false;
     private boolean supportRangeRequests = false;
     private java.util.concurrent.atomic.AtomicReference<String> rangeHeaderSink = null;
+    private java.util.concurrent.atomic.AtomicInteger rangeRequestCounter = null;
     private Authentication511Requester authenticationRequester;
 
     public TinyHttpdImpl(Socket socket, File dir) {
@@ -130,6 +131,14 @@ public class TinyHttpdImpl extends Thread {
      */
     public void setRangeHeaderSink(java.util.concurrent.atomic.AtomicReference<String> rangeHeaderSink) {
         this.rangeHeaderSink = rangeHeaderSink;
+    }
+
+    /**
+     * Shared counter incremented once per request that carries a Range header, so a test can
+     * assert how many Range requests were issued (e.g. multipart resume skip). Optional.
+     */
+    public void setRangeRequestCounter(java.util.concurrent.atomic.AtomicInteger rangeRequestCounter) {
+        this.rangeRequestCounter = rangeRequestCounter;
     }
 
     public int getPort() {
@@ -271,6 +280,9 @@ public class TinyHttpdImpl extends Thread {
                             }
                             if (rangeHeaderSink != null && rangeHeader != null) {
                                 rangeHeaderSink.set(rangeHeader);
+                            }
+                            if (rangeRequestCounter != null && rangeHeader != null) {
+                                rangeRequestCounter.incrementAndGet();
                             }
                         }
                         RangeSlice slice = supportRangeRequests ? parseRange(rangeHeader, resourceLength) : null;

--- a/tests/test-extensions/net/sourceforge/jnlp/TinyHttpdImpl.java
+++ b/tests/test-extensions/net/sourceforge/jnlp/TinyHttpdImpl.java
@@ -74,6 +74,8 @@ public class TinyHttpdImpl extends Thread {
     private boolean canRun = true;
     private boolean supportingHeadRequest = true;
     private boolean supportLastModified = false;
+    private boolean supportRangeRequests = false;
+    private java.util.concurrent.atomic.AtomicReference<String> rangeHeaderSink = null;
     private Authentication511Requester authenticationRequester;
 
     public TinyHttpdImpl(Socket socket, File dir) {
@@ -106,6 +108,28 @@ public class TinyHttpdImpl extends Thread {
 
     public boolean isSupportingLastModified() {
         return this.supportLastModified;
+    }
+
+    /**
+     * Enable HTTP Range (RFC 7233) serving: parse a {@code Range} request header and
+     * answer with 206 Partial Content (or 416 when unsatisfiable). One request per
+     * connection in this mode. Off by default so existing tests are unaffected.
+     */
+    public void setSupportRangeRequests(boolean supportRangeRequests) {
+        this.supportRangeRequests = supportRangeRequests;
+    }
+
+    public boolean isSupportingRangeRequests() {
+        return this.supportRangeRequests;
+    }
+
+    /**
+     * Shared holder that records the last seen {@code Range} request header value, so a
+     * test can assert the client actually sent a resume request. Set by ServerLauncher
+     * so it survives across per-connection instances.
+     */
+    public void setRangeHeaderSink(java.util.concurrent.atomic.AtomicReference<String> rangeHeaderSink) {
+        this.rangeHeaderSink = rangeHeaderSink;
     }
 
     public int getPort() {
@@ -234,6 +258,23 @@ public class TinyHttpdImpl extends Thread {
                         fis.read(buff);
                         fis.close();
 
+                        // When Range support is on, consume the request headers to find a Range:
+                        // header and answer with 206 Partial Content (RFC 7233). One request per
+                        // connection in this mode (the headers are drained here, not after serving).
+                        String rangeHeader = null;
+                        if (supportRangeRequests) {
+                            String h;
+                            while ((h = reader.readLine()) != null && h.length() > 0) {
+                                if (rangeHeader == null && h.regionMatches(true, 0, "Range:", 0, 6)) {
+                                    rangeHeader = h.substring(6).trim();
+                                }
+                            }
+                            if (rangeHeaderSink != null && rangeHeader != null) {
+                                rangeHeaderSink.set(rangeHeader);
+                            }
+                        }
+                        RangeSlice slice = supportRangeRequests ? parseRange(rangeHeader, resourceLength) : null;
+
                         String contentType = "Content-Type: ";
                         if (filePath.toLowerCase().endsWith(".jnlp")) {
                             contentType += "application/x-java-jnlp-file";
@@ -246,19 +287,40 @@ public class TinyHttpdImpl extends Thread {
                         if (supportLastModified) {
                             lastModified = "Last-Modified: " + new Date(resource.lastModified()) + CRLF;
                         }
-                        writer.writeBytes(HTTP_OK + "Content-Length:" + resourceLength + CRLF + lastModified + contentType + CRLF + CRLF);
 
-                        if (isGetRequest) {
-                            if (slowSend) {
-                                byte[][] bb = splitArray(buff, 10);
-                                for (int j = 0; j < bb.length; j++) {
-                                    Thread.sleep(2000);
-                                    byte[] bs = bb[j];
-                                    writer.write(bs, 0, bs.length);
-                                }
-                            } else {
-                                writer.write(buff, 0, resourceLength);
+                        if (slice != null && slice.unsatisfiable) {
+                            writer.writeBytes("HTTP/1.0 416 Range Not Satisfiable" + CRLF);
+                            writer.writeBytes("Content-Range: bytes */" + resourceLength + CRLF);
+                            writer.writeBytes("Accept-Ranges: bytes" + CRLF + CRLF);
+                        } else if (slice != null) {
+                            writer.writeBytes("HTTP/1.0 206 Partial Content" + CRLF);
+                            writer.writeBytes("Content-Length:" + slice.length + CRLF);
+                            writer.writeBytes("Content-Range: bytes " + slice.start + "-" + slice.end
+                                    + "/" + resourceLength + CRLF);
+                            writer.writeBytes("Accept-Ranges: bytes" + CRLF + lastModified + contentType + CRLF + CRLF);
+                            if (isGetRequest) {
+                                writer.write(buff, (int) slice.start, slice.length);
                             }
+                        } else {
+                            writer.writeBytes(HTTP_OK + "Content-Length:" + resourceLength + CRLF + lastModified + contentType + CRLF + CRLF);
+
+                            if (isGetRequest) {
+                                if (slowSend) {
+                                    byte[][] bb = splitArray(buff, 10);
+                                    for (int j = 0; j < bb.length; j++) {
+                                        Thread.sleep(2000);
+                                        byte[] bs = bb[j];
+                                        writer.write(bs, 0, bs.length);
+                                    }
+                                } else {
+                                    writer.write(buff, 0, resourceLength);
+                                }
+                            }
+                        }
+
+                        if (supportRangeRequests) {
+                            // Headers were drained above; this connection carries a single request.
+                            break;
                         }
                     }
                 }
@@ -273,6 +335,75 @@ public class TinyHttpdImpl extends Thread {
             }
         } catch (Exception e) {
             ServerAccess.logException(e, false);
+        }
+    }
+
+    /**
+     * Parse a single {@code Range: bytes=start-end|start-|-suffix} request value into the
+     * slice to serve. Returns {@code null} when there is no Range header (serve full 200),
+     * a satisfiable {@link RangeSlice} for a valid range, or an {@code unsatisfiable} slice
+     * (416) when the range is malformed/out of bounds.
+     */
+    static RangeSlice parseRange(String rangeHeader, int resourceLength) {
+        if (rangeHeader == null) {
+            return null;
+        }
+        String h = rangeHeader.trim();
+        int eq = h.indexOf('=');
+        if (eq == -1 || !h.substring(0, eq).trim().equalsIgnoreCase("bytes")) {
+            return null;
+        }
+        String spec = h.substring(eq + 1).trim();
+        int comma = spec.indexOf(',');
+        if (comma != -1) {
+            spec = spec.substring(0, comma).trim();
+        }
+        int dash = spec.indexOf('-');
+        if (dash == -1) {
+            return new RangeSlice(true, 0, 0, 0); // malformed -> treat as 416
+        }
+        String s = spec.substring(0, dash).trim();
+        String e = spec.substring(dash + 1).trim();
+        try {
+            long start;
+            long end;
+            if (s.isEmpty()) {
+                if (e.isEmpty()) {
+                    return new RangeSlice(true, 0, 0, 0);
+                }
+                long suffix = Long.parseLong(e);
+                if (suffix <= 0) {
+                    return new RangeSlice(true, 0, 0, 0);
+                }
+                start = Math.max(0L, resourceLength - suffix);
+                end = resourceLength - 1L;
+            } else {
+                start = Long.parseLong(s);
+                end = e.isEmpty() ? resourceLength - 1L : Long.parseLong(e);
+            }
+            if (resourceLength <= 0 || start >= resourceLength || start > end) {
+                return new RangeSlice(true, 0, 0, 0);
+            }
+            if (end >= resourceLength) {
+                end = resourceLength - 1L;
+            }
+            return new RangeSlice(false, start, end, (int) (end - start + 1));
+        } catch (NumberFormatException ex) {
+            return new RangeSlice(true, 0, 0, 0);
+        }
+    }
+
+    static final class RangeSlice {
+        final boolean unsatisfiable;
+        final long start;
+        final long end;
+        final int length;
+
+        RangeSlice(boolean unsatisfiable, long start, long end, int length) {
+            this.unsatisfiable = unsatisfiable;
+            this.start = start;
+            this.end = end;
+            this.length = length;
         }
     }
 


### PR DESCRIPTION
## Summary
- Resume interrupted JAR downloads with RFC 7233 `Range` / `If-Range` (206 append; 200 / 416 / Content-Range mismatch fall back to a full GET).
- Split large fresh identity downloads into parallel chunks (`deployment.http.range.maxSlotBytes`, default 50 MiB) on a shared pool; persist parts so a retry skips completed chunks.
- Per-session, per-origin memory: a 200 in answer to a Range probe marks the host range-unaware so later JARs in that launch use a plain GET (6.0.2). JNLP stays a plain GET so it cannot poison that note.
