### PR TITLE
feat: HTTP socket receive buffer for high-RTT downloads (#35)

### DIFF
--- a/netx/net/sourceforge/jnlp/config/Defaults.java
+++ b/netx/net/sourceforge/jnlp/config/Defaults.java
@@ -434,11 +434,11 @@ public class Defaults {
                         BasicValueValidators.getRangedIntegerValidator(0, 300000),
                         String.valueOf(30000)
                 },
-                /* SO_RCVBUF (bytes). 256 KiB covers ~6.8 Mbps at 300 ms RTT. 0 = OS default. */
+                /* SO_RCVBUF (bytes). 1024 KiB covers ~27 Mbps at 300 ms RTT. 0 = OS default. */
                 {
                         DeploymentConfiguration.KEY_HTTPCONNECTION_RECEIVE_BUFFER_SIZE,
                         BasicValueValidators.getRangedIntegerValidator(0, 16 * 1024 * 1024),
-                        String.valueOf(256 * 1024)
+                        String.valueOf(1024 * 1024)
                 },
                 /* SO_SNDBUF (bytes). 0 = do not set. */
                 {

--- a/netx/net/sourceforge/jnlp/config/Defaults.java
+++ b/netx/net/sourceforge/jnlp/config/Defaults.java
@@ -434,6 +434,18 @@ public class Defaults {
                         BasicValueValidators.getRangedIntegerValidator(0, 300000),
                         String.valueOf(30000)
                 },
+                /* SO_RCVBUF (bytes). 256 KiB covers ~6.8 Mbps at 300 ms RTT. 0 = OS default. */
+                {
+                        DeploymentConfiguration.KEY_HTTPCONNECTION_RECEIVE_BUFFER_SIZE,
+                        BasicValueValidators.getRangedIntegerValidator(0, 16 * 1024 * 1024),
+                        String.valueOf(256 * 1024)
+                },
+                /* SO_SNDBUF (bytes). 0 = do not set. */
+                {
+                        DeploymentConfiguration.KEY_HTTPCONNECTION_SEND_BUFFER_SIZE,
+                        BasicValueValidators.getRangedIntegerValidator(0, 16 * 1024 * 1024),
+                        String.valueOf(0)
+                },
                 /* TLS cipher suite preference (CSV; empty = use cipherMode) */
                 {
                         DeploymentConfiguration.KEY_TLS_CLIENT_CIPHER_SUITES,

--- a/netx/net/sourceforge/jnlp/config/DeploymentConfiguration.java
+++ b/netx/net/sourceforge/jnlp/config/DeploymentConfiguration.java
@@ -287,6 +287,19 @@ public final class DeploymentConfiguration {
     public static final String KEY_UPDATE_TIMEOUT = "deployment.javaws.update.timeout";
     public static final String KEY_HTTPCONNECTION_CONNECT_TIMEOUT = "deployment.http.connection.connectTimeout";
     public static final String KEY_HTTPCONNECTION_READ_TIMEOUT = "deployment.http.connection.readTimeout";
+    /**
+     * Socket {@code SO_RCVBUF} in bytes for HTTP(S) downloads. Default
+     * {@code 262144} (256 KiB) so one GET can advertise a window that covers a
+     * high-RTT path. {@code 0} leaves the OS autotune / stack default.
+     * Parallel downloads are unchanged.
+     */
+    public static final String KEY_HTTPCONNECTION_RECEIVE_BUFFER_SIZE =
+            "deployment.http.connection.receiveBufferSize";
+    /**
+     * Socket {@code SO_SNDBUF} in bytes. {@code 0} (default) does not set it.
+     */
+    public static final String KEY_HTTPCONNECTION_SEND_BUFFER_SIZE =
+            "deployment.http.connection.sendBufferSize";
     public static final String KEY_TLS_CLIENT_CIPHER_SUITES = "deployment.tls.client.cipherSuites";
     /**
      * When {@code true}, TLS offers a short fastest-cipher probe (see

--- a/netx/net/sourceforge/jnlp/config/DeploymentConfiguration.java
+++ b/netx/net/sourceforge/jnlp/config/DeploymentConfiguration.java
@@ -289,7 +289,7 @@ public final class DeploymentConfiguration {
     public static final String KEY_HTTPCONNECTION_READ_TIMEOUT = "deployment.http.connection.readTimeout";
     /**
      * Socket {@code SO_RCVBUF} in bytes for HTTP(S) downloads. Default
-     * {@code 262144} (256 KiB) so one GET can advertise a window that covers a
+     * {@code 1048576} (1024 KiB) so one GET can advertise a window that covers a
      * high-RTT path. {@code 0} leaves the OS autotune / stack default.
      * Parallel downloads are unchanged.
      */

--- a/netx/net/sourceforge/jnlp/security/ApacheHttpClient.java
+++ b/netx/net/sourceforge/jnlp/security/ApacheHttpClient.java
@@ -29,6 +29,7 @@ import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.io.SocketConfig;
 import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.pool.PoolStats;
 import org.apache.hc.core5.util.TimeValue;
@@ -58,6 +59,7 @@ public final class ApacheHttpClient implements ItwHttpClient {
                 ItwSslSocketFactory.shared(), null) {
             @Override
             protected void prepareSocket(SSLSocket socket, HttpContext context) throws IOException {
+                HttpSocketBuffers.apply(socket);
                 ItwSslSocketFactory.applyParameters(socket);
             }
         };
@@ -76,15 +78,26 @@ public final class ApacheHttpClient implements ItwHttpClient {
         int perRoute = downloadSlots();
         int maxTotal = Math.max(perRoute * 2, perRoute);
         System.setProperty("http.maxConnections", String.valueOf(perRoute));
+        SocketConfig.Builder socket = SocketConfig.custom();
+        int rcvBuf = HttpSocketBuffers.receiveBufferSize();
+        if (rcvBuf > 0) {
+            socket.setRcvBufSize(rcvBuf);
+        }
+        int sndBuf = HttpSocketBuffers.sendBufferSize();
+        if (sndBuf > 0) {
+            socket.setSndBufSize(sndBuf);
+        }
         PoolingHttpClientConnectionManager pool = PoolingHttpClientConnectionManagerBuilder.create()
                 .setSSLSocketFactory(sslsf)
                 .setMaxConnTotal(maxTotal)
                 .setMaxConnPerRoute(perRoute)
                 .setDefaultConnectionConfig(connectionConfig)
+                .setDefaultSocketConfig(socket.build())
                 .build();
         try {
             OutputController.getLogger().log(OutputController.Level.MESSAGE_ALL,
-                    "HTTP connection pool maxPerRoute=" + perRoute + " maxTotal=" + maxTotal);
+                    "HTTP connection pool maxPerRoute=" + perRoute + " maxTotal=" + maxTotal
+                            + " rcvBuf=" + rcvBuf + " sndBuf=" + sndBuf);
         } catch (Exception ignored) {
         }
 

--- a/netx/net/sourceforge/jnlp/security/HttpSocketBuffers.java
+++ b/netx/net/sourceforge/jnlp/security/HttpSocketBuffers.java
@@ -1,0 +1,59 @@
+package net.sourceforge.jnlp.security;
+
+import java.net.Socket;
+import java.net.SocketException;
+import net.sourceforge.jnlp.config.DeploymentConfiguration;
+import net.sourceforge.jnlp.runtime.JNLPRuntime;
+import net.sourceforge.jnlp.util.logging.OutputController;
+
+/**
+ * Applies {@code SO_RCVBUF} / {@code SO_SNDBUF} from deployment properties so
+ * one HTTP GET can advertise a window that covers a high-RTT path. Parallel
+ * download slots are unchanged. {@code 0} means do not call set (OS autotune).
+ */
+public final class HttpSocketBuffers {
+
+    public static final int DEFAULT_RECEIVE_BUFFER = 256 * 1024;
+
+    private HttpSocketBuffers() {
+    }
+
+    public static int receiveBufferSize() {
+        return sized(DeploymentConfiguration.KEY_HTTPCONNECTION_RECEIVE_BUFFER_SIZE, DEFAULT_RECEIVE_BUFFER);
+    }
+
+    public static int sendBufferSize() {
+        return sized(DeploymentConfiguration.KEY_HTTPCONNECTION_SEND_BUFFER_SIZE, 0);
+    }
+
+    public static void apply(Socket socket) {
+        if (socket == null) {
+            return;
+        }
+        int rcv = receiveBufferSize();
+        if (rcv > 0) {
+            try {
+                socket.setReceiveBufferSize(rcv);
+            } catch (SocketException e) {
+                OutputController.getLogger().log(OutputController.Level.ERROR_DEBUG, e);
+            }
+        }
+        int snd = sendBufferSize();
+        if (snd > 0) {
+            try {
+                socket.setSendBufferSize(snd);
+            } catch (SocketException e) {
+                OutputController.getLogger().log(OutputController.Level.ERROR_DEBUG, e);
+            }
+        }
+    }
+
+    private static int sized(String key, int fallback) {
+        try {
+            int n = Integer.parseInt(JNLPRuntime.getConfiguration().getProperty(key).trim());
+            return n < 0 ? fallback : n;
+        } catch (Exception e) {
+            return fallback;
+        }
+    }
+}

--- a/netx/net/sourceforge/jnlp/security/HttpSocketBuffers.java
+++ b/netx/net/sourceforge/jnlp/security/HttpSocketBuffers.java
@@ -13,7 +13,7 @@ import net.sourceforge.jnlp.util.logging.OutputController;
  */
 public final class HttpSocketBuffers {
 
-    public static final int DEFAULT_RECEIVE_BUFFER = 256 * 1024;
+    public static final int DEFAULT_RECEIVE_BUFFER = 1024 * 1024;
 
     private HttpSocketBuffers() {
     }

--- a/netx/net/sourceforge/jnlp/security/ItwSslSocketFactory.java
+++ b/netx/net/sourceforge/jnlp/security/ItwSslSocketFactory.java
@@ -92,10 +92,12 @@ public final class ItwSslSocketFactory extends SSLSocketFactory {
      * pass, which otherwise overwrites {@link SSLSocket#setEnabledCipherSuites}.
      */
     static void applyParameters(SSLSocket sock) {
+        HttpSocketBuffers.apply(sock);
         sock.setSSLParameters(ItwTls.parametersFor(peerHost(sock)));
     }
 
     private SSLSocket stamp(SSLSocket sock, String host) {
+        HttpSocketBuffers.apply(sock);
         sock.setSSLParameters(ItwTls.parametersFor(host != null ? host : peerHost(sock)));
         sock.addHandshakeCompletedListener(e -> {
             SSLSession s = e.getSession();

--- a/tests/netx/unit/net/sourceforge/jnlp/security/HttpSocketBuffersTest.java
+++ b/tests/netx/unit/net/sourceforge/jnlp/security/HttpSocketBuffersTest.java
@@ -1,0 +1,86 @@
+package net.sourceforge.jnlp.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.ServerSocket;
+import java.net.Socket;
+import net.sourceforge.jnlp.config.DeploymentConfiguration;
+import net.sourceforge.jnlp.runtime.JNLPRuntime;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+public class HttpSocketBuffersTest {
+
+    private String savedRcv;
+    private String savedSnd;
+
+    private void save() {
+        savedRcv = JNLPRuntime.getConfiguration()
+                .getProperty(DeploymentConfiguration.KEY_HTTPCONNECTION_RECEIVE_BUFFER_SIZE);
+        savedSnd = JNLPRuntime.getConfiguration()
+                .getProperty(DeploymentConfiguration.KEY_HTTPCONNECTION_SEND_BUFFER_SIZE);
+    }
+
+    @AfterEach
+    public void restore() {
+        if (savedRcv != null) {
+            JNLPRuntime.getConfiguration()
+                    .setProperty(DeploymentConfiguration.KEY_HTTPCONNECTION_RECEIVE_BUFFER_SIZE, savedRcv);
+        }
+        if (savedSnd != null) {
+            JNLPRuntime.getConfiguration()
+                    .setProperty(DeploymentConfiguration.KEY_HTTPCONNECTION_SEND_BUFFER_SIZE, savedSnd);
+        }
+    }
+
+    @Test
+    public void defaultReceiveBufferIs256KiB() {
+        save();
+        JNLPRuntime.getConfiguration().setProperty(
+                DeploymentConfiguration.KEY_HTTPCONNECTION_RECEIVE_BUFFER_SIZE, "262144");
+        JNLPRuntime.getConfiguration().setProperty(
+                DeploymentConfiguration.KEY_HTTPCONNECTION_SEND_BUFFER_SIZE, "0");
+        assertEquals(256 * 1024, HttpSocketBuffers.receiveBufferSize());
+        assertEquals(0, HttpSocketBuffers.sendBufferSize());
+    }
+
+    @Test
+    public void zeroMeansDoNotSet() throws Exception {
+        save();
+        JNLPRuntime.getConfiguration().setProperty(
+                DeploymentConfiguration.KEY_HTTPCONNECTION_RECEIVE_BUFFER_SIZE, "0");
+        JNLPRuntime.getConfiguration().setProperty(
+                DeploymentConfiguration.KEY_HTTPCONNECTION_SEND_BUFFER_SIZE, "0");
+        try (ServerSocket server = new ServerSocket(0);
+                Socket client = new Socket("127.0.0.1", server.getLocalPort());
+                Socket accepted = server.accept()) {
+            int before = client.getReceiveBufferSize();
+            HttpSocketBuffers.apply(client);
+            assertEquals(before, client.getReceiveBufferSize());
+            HttpSocketBuffers.apply(accepted);
+        }
+    }
+
+    @Test
+    public void applyRaisesReceiveBuffer() throws Exception {
+        save();
+        int want = 256 * 1024;
+        JNLPRuntime.getConfiguration().setProperty(
+                DeploymentConfiguration.KEY_HTTPCONNECTION_RECEIVE_BUFFER_SIZE, String.valueOf(want));
+        try (ServerSocket server = new ServerSocket(0);
+                Socket client = new Socket()) {
+            HttpSocketBuffers.apply(client);
+            client.connect(new java.net.InetSocketAddress("127.0.0.1", server.getLocalPort()));
+            try (Socket accepted = server.accept()) {
+                HttpSocketBuffers.apply(accepted);
+                // Kernel rmem_max may clamp below the request (seen 208 KiB for 256 KiB).
+                // Must not stay at the ~8 KiB that caps a high-RTT GET at ~200 kbps.
+                assertTrue(client.getReceiveBufferSize() >= 64 * 1024,
+                        "rcv=" + client.getReceiveBufferSize());
+                assertTrue(accepted.getReceiveBufferSize() >= 64 * 1024,
+                        "peer rcv=" + accepted.getReceiveBufferSize());
+            }
+        }
+    }
+}

--- a/tests/netx/unit/net/sourceforge/jnlp/security/HttpSocketBuffersTest.java
+++ b/tests/netx/unit/net/sourceforge/jnlp/security/HttpSocketBuffersTest.java
@@ -35,13 +35,14 @@ public class HttpSocketBuffersTest {
     }
 
     @Test
-    public void defaultReceiveBufferIs256KiB() {
+    public void defaultReceiveBufferIs1024KiB() {
         save();
         JNLPRuntime.getConfiguration().setProperty(
-                DeploymentConfiguration.KEY_HTTPCONNECTION_RECEIVE_BUFFER_SIZE, "262144");
+                DeploymentConfiguration.KEY_HTTPCONNECTION_RECEIVE_BUFFER_SIZE, "1048576");
         JNLPRuntime.getConfiguration().setProperty(
                 DeploymentConfiguration.KEY_HTTPCONNECTION_SEND_BUFFER_SIZE, "0");
-        assertEquals(256 * 1024, HttpSocketBuffers.receiveBufferSize());
+        assertEquals(1024 * 1024, HttpSocketBuffers.DEFAULT_RECEIVE_BUFFER);
+        assertEquals(1024 * 1024, HttpSocketBuffers.receiveBufferSize());
         assertEquals(0, HttpSocketBuffers.sendBufferSize());
     }
 
@@ -65,7 +66,7 @@ public class HttpSocketBuffersTest {
     @Test
     public void applyRaisesReceiveBuffer() throws Exception {
         save();
-        int want = 256 * 1024;
+        int want = 1024 * 1024;
         JNLPRuntime.getConfiguration().setProperty(
                 DeploymentConfiguration.KEY_HTTPCONNECTION_RECEIVE_BUFFER_SIZE, String.valueOf(want));
         try (ServerSocket server = new ServerSocket(0);


### PR DESCRIPTION
## Summary
- Set `SO_RCVBUF` from `deployment.http.connection.receiveBufferSize` (default **1 MiB**; `0` leaves OS autotune) so one HTTP GET can advertise a window that covers a high-RTT path.
- Optional `deployment.http.connection.sendBufferSize` (default `0` = do not set). Applied on Apache `SocketConfig` and on `ItwSslSocketFactory` / `prepareSocket`.
- Pool log now includes `rcvBuf=` / `sndBuf=`. Parallel download slots are unchanged. Linux `rmem_max` may still clamp the requested size.
